### PR TITLE
Replace SelfType with family of RecursiveTypes

### DIFF
--- a/core/src/main/kotlin/links/DRI.kt
+++ b/core/src/main/kotlin/links/DRI.kt
@@ -68,8 +68,8 @@ data class TypeConstructor(
             (if (params.isNotEmpty()) "[${params.joinToString(",")}]" else "")
 }
 
-object SelfType : TypeReference() {
-    override fun toString() = "^"
+data class RecursiveType(val rank: Int): TypeReference() {
+    override fun toString() = "^".repeat(rank + 1)
 }
 
 data class Nullable(val wrapped: TypeReference) : TypeReference() {


### PR DESCRIPTION
Fixes #1342 
It turned out that `SelfType` is insufficient to represent all possible recursive type bounds. It can represent bounds like `<T: List<S>, S: List<R>, R: List<T>>` but fails for `<T: List<S>, S: List<R>, R: List<S>>`.
This PR introduces `RecursiveType(rank: Int)`. Old `SelfType` is now `RecursiveType(0)`, The example above uses `RecursiveType(1)`.
Recursive types with a rank higher than 1 are possible and supported but require really exotic signatures, and even rank 1 was encountered by us for the first time recently.