### PR TITLE
Update analysis module references in CLI runner's docs

### DIFF
--- a/docs/topics/formats/dokka-javadoc.md
+++ b/docs/topics/formats/dokka-javadoc.md
@@ -56,12 +56,12 @@ by using the following goals:
 <tab title="CLI" group-key="cli">
 
 Since the Javadoc output format is a [Dokka plugin](dokka-plugins.md#apply-dokka-plugins), you need to 
-download the plugin's [JAR file](https://mvnrepository.com/artifact/org.jetbrains.dokka/javadoc-plugin/%dokkaVersion%).
+[download the plugin's JAR file](https://repo1.maven.org/maven2/org/jetbrains/dokka/javadoc-plugin/%dokkaVersion%/javadoc-plugin-%dokkaVersion%.jar).
 
 The Javadoc output format has two dependencies that you need to provide as additional JAR files:
 
-* [kotlin-as-java plugin](https://mvnrepository.com/artifact/org.jetbrains.dokka/kotlin-as-java-plugin/%dokkaVersion%)
-* [korte-jvm](https://mvnrepository.com/artifact/com.soywiz.korlibs.korte/korte-jvm/3.3.0)
+* [kotlin-as-java plugin](https://repo1.maven.org/maven2/org/jetbrains/dokka/kotlin-as-java-plugin/%dokkaVersion%/kotlin-as-java-plugin-%dokkaVersion%.jar)
+* [korte-jvm](https://repo1.maven.org/maven2/com/soywiz/korlibs/korte/korte-jvm/3.3.0/korte-jvm-3.3.0.jar)
 
 Via [command line options](dokka-cli.md#run-with-command-line-options):
 

--- a/docs/topics/formats/dokka-markdown.md
+++ b/docs/topics/formats/dokka-markdown.md
@@ -59,9 +59,9 @@ For more information, see the Mavin plugin documentation for [Other output forma
 </tab>
 <tab title="CLI" group-key="cli">
 
-Since GFM format is implemented as a [Dokka plugin](dokka-plugins.md#apply-dokka-plugins), you need to download the
-[JAR file](https://mvnrepository.com/artifact/org.jetbrains.dokka/gfm-plugin/%dokkaVersion%) and pass it to
-`pluginsClasspath`.
+Since GFM format is implemented as a [Dokka plugin](dokka-plugins.md#apply-dokka-plugins), you need to 
+[download the JAR file]((https://repo1.maven.org/maven2/org/jetbrains/dokka/gfm-plugin/%dokkaVersion%/gfm-plugin-%dokkaVersion%.jar))
+and pass it to `pluginsClasspath`.
 
 Via [command line options](dokka-cli.md#run-with-command-line-options):
 
@@ -137,9 +137,9 @@ For more information, see the Maven plugin's documentation for [Other output for
 </tab>
 <tab title="CLI" group-key="cli">
 
-Since Jekyll format is implemented as a [Dokka plugin](dokka-plugins.md#apply-dokka-plugins), you need to download the
-[JAR file](https://mvnrepository.com/artifact/org.jetbrains.dokka/jekyll-plugin/%dokkaVersion%). This format is also
-based on [GFM](#gfm) format, so you need to provide it as a dependency as well. Both JARs need to be passed to 
+Since Jekyll format is implemented as a [Dokka plugin](dokka-plugins.md#apply-dokka-plugins), you need to 
+[download the JAR file](https://repo1.maven.org/maven2/org/jetbrains/dokka/jekyll-plugin/%dokkaVersion%/jekyll-plugin-%dokkaVersion%.jar).
+This format is also based on [GFM](#gfm) format, so you need to provide it as a dependency as well. Both JARs need to be passed to 
 `pluginsClasspath`:
 
 Via [command line options](dokka-cli.md#run-with-command-line-options):

--- a/docs/topics/runners/dokka-cli.md
+++ b/docs/topics/runners/dokka-cli.md
@@ -10,8 +10,8 @@ difficult to set up as there is no autoconfiguration, especially in multiplatfor
 
 The CLI runner is published to Maven Central as a separate runnable artifact.
 
-You can find it on [mvnrepository](https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-cli/%dokkaVersion%) or by browsing
-[maven central repository directories](https://repo1.maven.org/maven2/org/jetbrains/dokka/dokka-cli/%dokkaVersion%) directly.
+You can find it on [Maven Central](https://central.sonatype.com/artifact/org.jetbrains.dokka/dokka-cli) or 
+[download it directly](https://repo1.maven.org/maven2/org/jetbrains/dokka/dokka-cli/%dokkaVersion%/dokka-cli-%dokkaVersion%.jar).
 
 With the `dokka-cli-%dokkaVersion%.jar` file saved on your computer, run it with the `-help` option to see all 
 available configuration options and their description:
@@ -34,17 +34,17 @@ Since there is no build tool to manage dependencies, you have to provide depende
 
 Listed below are the dependencies that you need for any output format:
 
-| **Group**             | **Artifact**                  | **Version**    | **Link**                                                                                                           |
-|-----------------------|-------------------------------|----------------|--------------------------------------------------------------------------------------------------------------------|
-| `org.jetbrains.dokka` | `dokka-base`                  | %dokkaVersion% | [mvnrepository](https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-base/%dokkaVersion%)                  |
-| `org.jetbrains.dokka` | `analysis-kotlin-descriptors` | %dokkaVersion% | [mvnrepository](https://mvnrepository.com/artifact/org.jetbrains.dokka/analysis-kotlin-descriptors/%dokkaVersion%) |
+| **Group**             | **Artifact**                  | **Version**    | **Link**                                                                                                                                                 |
+|-----------------------|-------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `org.jetbrains.dokka` | `dokka-base`                  | %dokkaVersion% | [download](https://repo1.maven.org/maven2/org/jetbrains/dokka/dokka-base/%dokkaVersion%/dokka-base-%dokkaVersion%.jar)                                   |
+| `org.jetbrains.dokka` | `analysis-kotlin-descriptors` | %dokkaVersion% | [download](https://repo1.maven.org/maven2/org/jetbrains/dokka/analysis-kotlin-descriptors/%dokkaVersion%/analysis-kotlin-descriptors-%dokkaVersion%.jar) |
 
 Below are the additional dependencies that you need for [HTML](dokka-html.md) output format:
 
-| **Group**               | **Artifact**       | **Version** | **Link**                                                                                         |
-|-------------------------|--------------------|-------------|--------------------------------------------------------------------------------------------------|
-| `org.jetbrains.kotlinx` | `kotlinx-html-jvm` | 0.8.0       | [mvnrepository](https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-html-jvm/0.8.0) |
-| `org.freemarker`        | `freemarker`       | 2.3.31      | [mvnrepository](https://mvnrepository.com/artifact/org.freemarker/freemarker/2.3.31)             |
+| **Group**               | **Artifact**       | **Version** | **Link**                                                                                                           |
+|-------------------------|--------------------|-------------|--------------------------------------------------------------------------------------------------------------------|
+| `org.jetbrains.kotlinx` | `kotlinx-html-jvm` | 0.8.0       | [download](https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.8.0/kotlinx-html-jvm-0.8.0.jar) |
+| `org.freemarker`        | `freemarker`       | 2.3.31      | [download](https://repo1.maven.org/maven2/org/freemarker/freemarker/2.3.31/freemarker-2.3.31.jar)                  |
 
 
 ### Run with command line options
@@ -113,8 +113,8 @@ All other output formats are implemented as [Dokka plugins](dokka-plugins.md). I
 on the plugins classpath.
 
 For example, if you want to generate documentation in the experimental [GFM](dokka-markdown.md#gfm) output format, you need to download and
-pass [gfm-plugin's JAR](https://mvnrepository.com/artifact/org.jetbrains.dokka/gfm-plugin/%dokkaVersion%) into 
-the `pluginsClasspath` configuration option.
+pass gfm-plugin's JAR ([download](https://repo1.maven.org/maven2/org/jetbrains/dokka/gfm-plugin/%dokkaVersion%/gfm-plugin-%dokkaVersion%.jar))
+into the `pluginsClasspath` configuration option.
 
 Via command line options:
 


### PR DESCRIPTION
Updated the user documentation for the CLI runner to use the new analysis modules instead of the old ones.

**Note**: this is done as a standalone PR on purpose (there will be a separate PR for the Developer guides), and it should be merged ONLY after Dokka 1.9.0 is released, otherwise changes will be deployed to kotlinlang automatically, and it's too soon.