### PR TITLE
Update Kotlin Slack signup link to use kotl.in shortlink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,4 +239,4 @@ A Build Scan may contain identifiable information. See the Terms of Use https://
 
 * If something cannot be done, not convenient, or does not work &mdash; submit an [issue](#submitting-issues).
 * Discussions and general inquiries &mdash; use `#dokka` channel in
-  [Kotlin Community Slack](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up).
+  [Kotlin Community Slack](https://kotl.in/slack).

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ which enable additional processing or modifications to the documentation generat
 
 ## Community
 
-Dokka has a dedicated `#dokka` channel in [Kotlin Community Slack](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up)
+Dokka has a dedicated `#dokka` channel in [Kotlin Community Slack](https://kotl.in/slack)
 where you can chat about Dokka, its plugins and how to develop them, as well as get in touch with maintainers.
 
 ## Building and Contributing

--- a/docs-developer/docs/developer_guide/community/slack.md
+++ b/docs-developer/docs/developer_guide/community/slack.md
@@ -3,5 +3,5 @@
 Dokka has a dedicated `#dokka` channel in the `Kotlin Community Slack`, where you can ask questions and chat 
 about using, customizing or contributing to Dokka. 
 
-[Follow the instructions](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up)
+[Follow the instructions](https://kotl.in/slack)
 to get an invite or [connect directly](https://kotlinlang.slack.com). 

--- a/docs/topics/dokka-introduction.md
+++ b/docs/topics/dokka-introduction.md
@@ -24,5 +24,5 @@ See [Get started with Dokka](dokka-get-started.md) to take your first steps in u
 
 ## Community
 
-Dokka has a dedicated `#dokka` channel in [Kotlin Community Slack](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up)
+Dokka has a dedicated `#dokka` channel in [Kotlin Community Slack](https://kotl.in/slack)
 where you can chat about Dokka, its plugins and how to develop them, as well as get in touch with maintainers.


### PR DESCRIPTION
Minor change - the short link already redirects to the same link.

Updating it just helps with consistency and resilience, in case it ever changes.