### PR TITLE
Fix merging of explicit expect/actual with a single callable declaration

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
@@ -172,9 +172,12 @@ public open class DefaultPageCreator(
 
     private fun <T : Documentable> List<T>.renameClashingDocumentable(): List<T> =
         groupBy { it.dri }.values.flatMap { elements ->
-            // do not rename [elements] if there is an explicit expect-actual
-            // they should be merged by [SameMethodNamePageMergerStrategy]
-            if(elements.any { it is WithIsExpectActual && it.isExpectActual }) return elements
+            //special case: property and function with the same DRI
+            if(elements.any { it is DProperty } && elements.any { it is DFunction }) {
+                // do not rename [elements] if there is an explicit expect-actual
+                // they should be merged by [SameMethodNamePageMergerStrategy]
+                if(elements.any { it is WithIsExpectActual && it.isExpectActual }) return elements
+            }
 
             if (elements.size == 1) elements else elements.mapNotNull { element ->
                 element.renameClashingDocumentable()


### PR DESCRIPTION
fixes #4311 

This is a corner case because a property and a function have the same DRI in the same source set. 