### PR TITLE
Fix CLI runner to force use of the latest stdlib

### DIFF
--- a/dokka-runners/runner-cli/gradle.properties
+++ b/dokka-runners/runner-cli/gradle.properties
@@ -8,5 +8,5 @@ version=2.1.0-SNAPSHOT
 
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
-org.jetbrains.dokka.enforceGradleKotlinCompatibility=true
+org.jetbrains.dokka.enforceGradleKotlinCompatibility=false
 kotlin.compiler.runViaBuildToolsApi=true

--- a/dokka-runners/runner-cli/src/main/kotlin/org/jetbrains/dokka/GlobalArguments.kt
+++ b/dokka-runners/runner-cli/src/main/kotlin/org/jetbrains/dokka/GlobalArguments.kt
@@ -117,7 +117,7 @@ public class GlobalArguments(args: Array<String>) : DokkaConfiguration {
 
     public val loggingLevel: LoggingLevel by parser.option(
         ArgType.Choice(toVariant = {
-            when (it.toUpperCase().trim()) {
+            when (it.uppercase().trim()) {
                 "DEBUG", "" -> LoggingLevel.DEBUG
                 "PROGRESS" -> LoggingLevel.PROGRESS
                 "INFO" -> LoggingLevel.INFO


### PR DESCRIPTION
Fixes https://teamcity.jetbrains.com/buildConfiguration/KotlinTools_Dokka_IntegrationTests/5619041
`Dokka Integration Tests [K2]` were run only on the Gradle projects.


The CLI runner uses its own version of stdlib instead of the shadowed stdlib from analysis (e.g., see #4229).
This PR has a quick fix.

The ideal solution is to have an isolated classloader like in #4182. Or `cli-runner` can be bundled with `symbols-analysis` without the ability to switch between K1 and K2.

