### PR TITLE
Fix `org.gradle.logging.stacktrace` property in `GradlePropertiesBuilder` test util

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradlePropertiesBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradlePropertiesBuilder.kt
@@ -126,7 +126,7 @@ data class GradlePropertiesBuilder(
             putNotNull("org.gradle.logging.level", logLevel?.name?.lowercase())
             putNotNull("org.gradle.workers.max", maxWorkers)
             putNotNull("org.gradle.parallel", parallel)
-            putNotNull("org.gradle.stacktrace", stacktrace)
+            putNotNull("org.gradle.logging.stacktrace", stacktrace)
             putNotNull("org.gradle.warning.mode", warningMode)
             jvmArgs.buildString().takeIf { it.isNotBlank() }?.let {
                 put("org.gradle.jvmargs", it)


### PR DESCRIPTION
The property `org.gradle.stacktrace` doesn't exist, the correct one is `org.gradle.logging.stacktrace`.