### PR TITLE
Use language-java class for <pre> and <code> tags generated from Java sources

### DIFF
--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/HtmlToDocTagConverter.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/doctag/HtmlToDocTagConverter.kt
@@ -54,10 +54,10 @@ internal class HtmlToDocTagConverter(
                     element.attributes().associate { (if (it.key == "src") "href" else it.key) to it.value })
             )
             "em" -> listOf(Em(children))
-            "code" -> ifChildrenPresent { if(keepFormatting) CodeBlock(children) else CodeInline(children) }
+            "code" -> ifChildrenPresent { if(keepFormatting) CodeBlock(children, mapOf("lang" to "java")) else CodeInline(children, mapOf("lang" to "java")) }
             "pre" -> if(children.size == 1) {
                 when(children.first()) {
-                    is CodeInline -> listOf(CodeBlock(children.first().children))
+                    is CodeInline -> listOf(CodeBlock(children.first().children, mapOf("lang" to "java")))
                     is CodeBlock -> listOf(children.first())
                     else -> listOf(Pre(children))
                 }

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/pages/comments/DocTagToContentConverter.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/transformers/pages/comments/DocTagToContentConverter.kt
@@ -148,7 +148,7 @@ public open class DocTagToContentConverter : CommentsToContentConverter {
             is CodeInline -> listOf(
                 ContentCodeInline(
                     buildChildren(docTag),
-                    "",
+                    docTag.params.getOrDefault("lang", ""),
                     dci,
                     sourceSets.toDisplaySourceSets(),
                     styles

--- a/dokka-subprojects/plugin-base/src/test/kotlin/parsers/JavadocParserTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/parsers/JavadocParserTest.kt
@@ -105,14 +105,20 @@ class JavadocParserTest : BaseAbstractTest() {
                 kotlin.test.assertEquals(
                     listOf(
                         Text(body = "Identifies calls to "),
-                        CodeInline(children = listOf(Text(body = "assertThat"))),
+                        CodeInline(children = listOf(Text(body = "assertThat")), mapOf("lang" to "java")),
                         Text(body = ". "),
-                        CodeInline(children = listOf(Text(body = "\nSet<String> s;\nSystem.out.println(\"s1 = \" + s);\n")))
+                        CodeInline(
+                            children = listOf(Text(body = "\nSet<String> s;\nSystem.out.println(\"s1 = \" + s);\n")),
+                            mapOf("lang" to "java")
+                        )
                     ),
                     root.children[0].children
                 )
                 kotlin.test.assertEquals(
-                    CodeBlock(children = listOf(Text(body = "\nSet<String> s2;\nSystem.out\n        .println(\"s2 = \" + s2);\n"))),
+                    CodeBlock(
+                        children = listOf(Text(body = "\nSet<String> s2;\nSystem.out\n        .println(\"s2 = \" + s2);\n")),
+                        mapOf("lang" to "java")
+                    ),
                     root.children[1]
                 )
             }
@@ -306,7 +312,8 @@ class JavadocParserTest : BaseAbstractTest() {
                                         )
                                     ),
                                     Text("\"")
-                                )
+                                ),
+                                mapOf("lang" to "java")
                             ),
                         )
                     ),
@@ -316,7 +323,8 @@ class JavadocParserTest : BaseAbstractTest() {
                             CodeInline(
                                 listOf(
                                     Text("path")
-                                )
+                                ),
+                                mapOf("lang" to "java")
                             ),
                             Text(" attribute. ")
                         )
@@ -333,7 +341,8 @@ class JavadocParserTest : BaseAbstractTest() {
                                         )
                                     ),
                                     Text("\"")
-                                )
+                                ),
+                                mapOf("lang" to "java")
                             )
                         )
                     ),


### PR DESCRIPTION
fix #4345