### PR TITLE
DGP integration tests: Add `@TestsKotlinJvm` tag

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/testTags.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/testTags.kt
@@ -39,6 +39,16 @@ annotation class TestsKotlinMultiplatform
 
 
 /**
+ * JUnit [Tag] indicating the test involves a Kotlin JVM project.
+ */
+@Tag("KotlinJvm")
+@Target(FUNCTION, CLASS)
+@MustBeDocumented
+@Inherited
+annotation class TestsKotlinJvm
+
+
+/**
  * JUnit [Tag] indicating the test involves an Android project.
  *
  * If a test is annotated with [TestsAndroid] then

--- a/dokka-integration-tests/gradle/src/test/kotlin/AndroidComposeIT.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/AndroidComposeIT.kt
@@ -24,6 +24,7 @@ import kotlin.io.path.readText
  */
 @TestsDGPv2
 @TestsAndroidCompose
+@TestsKotlinJvm
 @WithGradleProperties(GradlePropertiesProvider.Android::class)
 class AndroidComposeIT {
 

--- a/dokka-integration-tests/gradle/src/test/kotlin/AndroidProjectIT.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/AndroidProjectIT.kt
@@ -24,6 +24,7 @@ import kotlin.io.path.readText
  */
 @TestsAndroid
 @TestsDGPv2
+@TestsKotlinJvm
 @WithGradleProperties(GradlePropertiesProvider.Android::class)
 class AndroidProjectIT {
 

--- a/dokka-integration-tests/gradle/src/test/kotlin/MultiplatformAndroidJvmProjectIT.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/MultiplatformAndroidJvmProjectIT.kt
@@ -9,13 +9,9 @@ import io.kotest.matchers.paths.shouldBeAFile
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotContain
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.jetbrains.dokka.gradle.utils.*
 import org.jetbrains.dokka.gradle.utils.addArguments
 import org.jetbrains.dokka.gradle.utils.build
-import org.jetbrains.dokka.gradle.utils.findFiles
-import org.jetbrains.dokka.gradle.utils.shouldBeADirectoryWithSameContentAs
-import org.jetbrains.dokka.gradle.utils.shouldNotContainAnyOf
-import org.jetbrains.dokka.gradle.utils.sideBySide
-import org.jetbrains.dokka.gradle.utils.toTreeString
 import org.jetbrains.dokka.it.gradle.junit.*
 import kotlin.io.path.name
 import kotlin.io.path.readText
@@ -26,6 +22,7 @@ import kotlin.io.path.readText
 @TestsAndroid
 @TestsDGPv2
 @WithGradleProperties(GradlePropertiesProvider.Android::class)
+@TestsKotlinMultiplatform
 class MultiplatformAndroidJvmProjectIT {
 
     @DokkaGradlePluginTest(sourceProjectName = "it-multiplatform-android-jvm")


### PR DESCRIPTION
Tag tests that use Kotlin JVM plugin.

(This will become more relevant when we add a test for AGP9 with Kotlin-built-in.)