### PR TITLE
DGP integration tests: Move `@WithGradleProperties` to tags

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/testTags.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/testTags.kt
@@ -59,6 +59,7 @@ annotation class TestsKotlinJvm
 @Target(FUNCTION, CLASS)
 @MustBeDocumented
 @Inherited
+@WithGradleProperties(GradlePropertiesProvider.Android::class)
 annotation class TestsAndroid
 
 
@@ -74,4 +75,5 @@ annotation class TestsAndroid
 @Target(FUNCTION, CLASS)
 @MustBeDocumented
 @Inherited
+@WithGradleProperties(GradlePropertiesProvider.Android::class)
 annotation class TestsAndroidCompose

--- a/dokka-integration-tests/gradle/src/test/kotlin/AndroidComposeIT.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/AndroidComposeIT.kt
@@ -25,7 +25,6 @@ import kotlin.io.path.readText
 @TestsDGPv2
 @TestsAndroidCompose
 @TestsKotlinJvm
-@WithGradleProperties(GradlePropertiesProvider.Android::class)
 class AndroidComposeIT {
 
     @DokkaGradlePluginTest(sourceProjectName = "it-android-compose")

--- a/dokka-integration-tests/gradle/src/test/kotlin/AndroidProjectIT.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/AndroidProjectIT.kt
@@ -25,7 +25,6 @@ import kotlin.io.path.readText
 @TestsAndroid
 @TestsDGPv2
 @TestsKotlinJvm
-@WithGradleProperties(GradlePropertiesProvider.Android::class)
 class AndroidProjectIT {
 
     @DokkaGradlePluginTest(sourceProjectName = "it-android")

--- a/dokka-integration-tests/gradle/src/test/kotlin/MultiplatformAndroidJvmProjectIT.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/MultiplatformAndroidJvmProjectIT.kt
@@ -21,7 +21,6 @@ import kotlin.io.path.readText
  */
 @TestsAndroid
 @TestsDGPv2
-@WithGradleProperties(GradlePropertiesProvider.Android::class)
 @TestsKotlinMultiplatform
 class MultiplatformAndroidJvmProjectIT {
 


### PR DESCRIPTION
Move the `@WithGradleProperties` defaults to the tags that require them. The test classes are simpler.

(This will become more relevant when we need to test AGP9 with built-in-kotlin.)