### PR TITLE
KGP IT: Add default `gradle.properties` to Android properties

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/WithGradleProperties.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/WithGradleProperties.kt
@@ -36,6 +36,7 @@ fun interface GradlePropertiesProvider {
 
     object Android : GradlePropertiesProvider {
         override fun get(): Map<String, String> = buildMap {
+            putAll(Default.get())
             put("android.useAndroidX", "true")
         }
     }


### PR DESCRIPTION
Always add the default `gradle.properties` to Android properties.