### PR TITLE
Add constraints to `DRI`

### DIFF
--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
@@ -21,6 +21,11 @@ public data class DRI(
     val target: DriTarget = PointingToDeclaration,
     val extra: String? = null
 ) {
+    init {
+        fun CharSequence.isBlank(): Boolean = all { it.isWhitespace() }
+        require(classNames == null || !classNames.isBlank(), {"classNames should not be empty. For top-level declarations, null should be used" })
+        require((packageName == null && classNames == null) || packageName != null, {"packageName can be null only for the top-level DRI of a module, see [DRI.topLevel]. For the default package, an empty string should be used" })
+    }
     override fun toString(): String =
         "${packageName.orEmpty()}/${classNames.orEmpty()}/${callable?.name.orEmpty()}/${callable?.signature()
             .orEmpty()}/$target/${extra.orEmpty()}"

--- a/dokka-subprojects/plugin-base/src/test/kotlin/locationProvider/DefaultExternalLocationProviderTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/locationProvider/DefaultExternalLocationProviderTest.kt
@@ -51,7 +51,7 @@ class DefaultExternalLocationProviderTest : BaseAbstractTest() {
         val locationProvider = getTestLocationProvider()
         val dri = DRI(
             "",
-            "",
+            null,
             Callable(
                 "longArray",
                 null,

--- a/dokka-subprojects/plugin-base/src/test/kotlin/locationProvider/Dokka010ExternalLocationProviderTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/locationProvider/Dokka010ExternalLocationProviderTest.kt
@@ -59,7 +59,7 @@ class Dokka010ExternalLocationProviderTest : BaseAbstractTest() {
         val locationProvider = getTestLocationProvider()
         val dri = DRI(
             "kotlin",
-            "",
+            null,
             Callable(
                 "minus",
                 null,


### PR DESCRIPTION
Sometimes it is confusing to write a correct `DRI` for a top-level declaration, especially when the string representation of `null` and an empty string are the same in `DRI.toString`.