### PR TITLE
Fix minor oversight in the implemenation: missed `+` in enum entries

### DIFF
--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
@@ -118,7 +118,7 @@ public open class DefaultPageCreator(
                     props.mergeClashingDocumentable().map(::pageForProperties)
         else
             classlikes.renameClashingDocumentable().map(::pageForClasslike) +
-                    functions.renameClashingDocumentable().map(::pageForFunction)
+                    functions.renameClashingDocumentable().map(::pageForFunction) +
                     props.renameClashingDocumentable().mapNotNull(::pageForProperty)
 
         return ClasslikePageNode(
@@ -160,8 +160,8 @@ public open class DefaultPageCreator(
                             entries.mergeClashingDocumentable().map(::pageForEnumEntries)
                 else
                     (nestedClasslikes + typealiases).renameClashingDocumentable().map(::pageForClasslike) +
-                            functions.renameClashingDocumentable().map(::pageForFunction)  +
-                            props.renameClashingDocumentable().mapNotNull(::pageForProperty)  +
+                            functions.renameClashingDocumentable().map(::pageForFunction) +
+                            props.renameClashingDocumentable().mapNotNull(::pageForProperty) +
                             entries.renameClashingDocumentable().map(::pageForEnumEntry)
 
 


### PR DESCRIPTION
Overall, looks like it hasn't caused any issues, because we don't render members for enum entries, but still, it's a bit strange :)