### PR TITLE
Enable "KDoc reference to class from constructor" test

### DIFF
--- a/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisEnvironment.kt
+++ b/dokka-subprojects/analysis-kotlin-descriptors-compiler/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/descriptors/compiler/configuration/AnalysisEnvironment.kt
@@ -55,8 +55,8 @@ import org.jetbrains.kotlin.js.config.JSConfigurationKeys
 import org.jetbrains.kotlin.js.resolve.JsPlatformAnalyzerServices
 import org.jetbrains.kotlin.library.KLIB_FILE_EXTENSION
 import org.jetbrains.kotlin.library.KotlinLibrary
-import org.jetbrains.kotlin.library.SingleFileKlibResolveStrategy
-import org.jetbrains.kotlin.library.ToolingSingleFileKlibResolveStrategy
+import org.jetbrains.kotlin.library.loader.KlibLoader
+import org.jetbrains.kotlin.library.loader.reportLoadingProblemsIfAny
 import org.jetbrains.kotlin.load.java.structure.impl.JavaClassImpl
 import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass
 import org.jetbrains.kotlin.name.Name
@@ -76,6 +76,7 @@ import org.jetbrains.kotlin.resolve.jvm.platform.JvmPlatformAnalyzerServices
 import org.jetbrains.kotlin.resolve.konan.platform.NativePlatformAnalyzerServices
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 import org.jetbrains.kotlin.util.DummyLogger
+import org.jetbrains.kotlin.util.Logger
 import java.io.File
 import org.jetbrains.kotlin.konan.file.File as KFile
 
@@ -305,8 +306,7 @@ public class AnalysisEnvironment(
                 .filter { it.isDirectory || it.extension == KLIB_FILE_EXTENSION }
                 .forEach { libraryFile ->
                     try {
-                        val kotlinLibrary = ToolingSingleFileKlibResolveStrategy
-                            .resolve(KFile(libraryFile.absolutePath), DummyLogger)
+                        val kotlinLibrary = resolveSingleFileKlib(KFile(libraryFile.absolutePath), DummyLogger)
                         if (kLibService.isAnalysisCompatible(kotlinLibrary)) {
                             // exists, is KLIB, has compatible format
                             result.put(
@@ -587,4 +587,12 @@ public class AnalysisEnvironment(
         Disposer.dispose(this)
     }
 
+}
+
+private fun resolveSingleFileKlib(libraryFile: KFile, logger: Logger): KotlinLibrary {
+    val klibLoadingResult = KlibLoader { libraryPaths(libraryFile.path) }.load()
+    klibLoadingResult.reportLoadingProblemsIfAny { _, message ->
+        logger.error(message)
+    }
+    return klibLoadingResult.librariesStdlibFirst.single()
 }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/content/kdoc/KDocAmbiguityResolutionTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/content/kdoc/KDocAmbiguityResolutionTest.kt
@@ -30,7 +30,6 @@ import org.jetbrains.dokka.pages.MemberPageNode
 import utils.OnlySymbols
 import utils.findTestType
 import utils.withExperimentalKDocResolution
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -536,7 +535,6 @@ class KDocAmbiguityResolutionTest : BaseAbstractTest() {
 
 
     @Test
-    @Ignore("#3604: blocked by KT-83152")
     fun `#3604 KDoc reference to class from constructor`() = withExperimentalKDocResolution {
         testInline(
             """

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,8 +21,8 @@ ktor = "2.3.11"
 javaDiffUtils = "4.12"
 
 ## Analysis
-kotlin-compiler = "2.3.20-dev-7064"
-kotlin-compiler-k2 = "2.3.20-dev-7064"
+kotlin-compiler = "2.4.0-dev-169"
+kotlin-compiler-k2 = "2.4.0-dev-169"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations


### PR DESCRIPTION
* Update to new AA
* Enable test for constructors
* Fix removed/deprecated API usages