### PR TITLE
Refactor assertions for `sourceLinks` and `externalDocumentationLinks` to improve comparison consistency in tests

### DIFF
--- a/dokka-subprojects/core-test-api/src/main/kotlin/org/jetbrains/dokka/testApi/configuration.kt
+++ b/dokka-subprojects/core-test-api/src/main/kotlin/org/jetbrains/dokka/testApi/configuration.kt
@@ -61,13 +61,9 @@ public fun assertDokkaSourceSetEquals(
     assertEquals(expected.skipEmptyPackages, actual.skipEmptyPackages, "DokkaSourceSet.skipEmptyPackages")
     assertEquals(expected.skipDeprecated, actual.skipDeprecated, "DokkaSourceSet.skipDeprecated")
     assertEquals(expected.jdkVersion, actual.jdkVersion, "DokkaSourceSet.jdkVersion")
-    assertEquals(expected.sourceLinks, actual.sourceLinks, "DokkaSourceSet.sourceLinks")
+    assertSourceLinksEquals(expected.sourceLinks, actual.sourceLinks)
     assertEquals(expected.perPackageOptions, actual.perPackageOptions, "DokkaSourceSet.perPackageOptions")
-    assertEquals(
-        expected.externalDocumentationLinks,
-        actual.externalDocumentationLinks,
-        "DokkaSourceSet.externalDocumentationLinks"
-    )
+    assertExternalDocumentationLinksEquals(expected.externalDocumentationLinks, actual.externalDocumentationLinks)
     assertEquals(expected.languageVersion, actual.languageVersion, "DokkaSourceSet.languageVersion")
     assertEquals(expected.apiVersion, actual.apiVersion, "DokkaSourceSet.apiVersion")
     assertEquals(expected.noStdlibLink, actual.noStdlibLink, "DokkaSourceSet.noStdlibLink")
@@ -78,5 +74,36 @@ public fun assertDokkaSourceSetEquals(
         expected.documentedVisibilities,
         actual.documentedVisibilities,
         "DokkaSourceSet.documentedVisibilities"
+    )
+}
+
+private fun assertSourceLinksEquals(
+    expected: Set<DokkaConfiguration.SourceLinkDefinition>,
+    actual: Set<DokkaConfiguration.SourceLinkDefinition>
+) {
+    fun transform(link: DokkaConfiguration.SourceLinkDefinition) = Triple(
+        link.localDirectory,
+        link.remoteUrl.toURI(), // to avoid URL.equals calls
+        link.remoteLineSuffix
+    )
+    assertEquals(
+        expected.mapTo(mutableSetOf(), ::transform),
+        actual.mapTo(mutableSetOf(), ::transform),
+        "DokkaSourceSet.sourceLinks"
+    )
+}
+
+private fun assertExternalDocumentationLinksEquals(
+    expected: Set<DokkaConfiguration.ExternalDocumentationLink>,
+    actual: Set<DokkaConfiguration.ExternalDocumentationLink>
+) {
+    fun transform(link: DokkaConfiguration.ExternalDocumentationLink) = Pair(
+        link.url.toURI(), // to avoid URL.equals calls
+        link.packageListUrl.toURI(), // to avoid URL.equals calls
+    )
+    assertEquals(
+        expected.mapTo(mutableSetOf(), ::transform),
+        actual.mapTo(mutableSetOf(), ::transform),
+        "DokkaSourceSet.externalDocumentationLinks"
     )
 }


### PR DESCRIPTION
Once in a while, we have test failures like this: https://github.com/Kotlin/dokka/actions/runs/21133153263/job/60768833039.

The failure message says:
```
org.opentest4j.AssertionFailedError: DokkaSourceSet.externalDocumentationLinks ==>
expected: java.util.LinkedHashSet@13cc31ae<[ExternalDocumentationLinkImpl(url=http://some.other.url, packageListUrl=http://some.url), ExternalDocumentationLinkImpl(url=https://docs.oracle.com/javase/8/docs/api/, packageListUrl=https://docs.oracle.com/javase/8/docs/api/package-list), ExternalDocumentationLinkImpl(url=https://kotlinlang.org/api/core/, packageListUrl=https://kotlinlang.org/api/core/package-list)]>
 but was: java.util.LinkedHashSet@5bb7a59 <[ExternalDocumentationLinkImpl(url=http://some.other.url, packageListUrl=http://some.url), ExternalDocumentationLinkImpl(url=https://docs.oracle.com/javase/8/docs/api/, packageListUrl=https://docs.oracle.com/javase/8/docs/api/package-list), ExternalDocumentationLinkImpl(url=https://kotlinlang.org/api/core/, packageListUrl=https://kotlinlang.org/api/core/package-list)]>	
```

Where `13cc31ae` and `5bb7a59` are the only differences. **The content of both sets is the same.**

You might ask: BUT WHY DOES IT FAIL?
The answer is most likely somewhere in [URL.equals](https://docs.oracle.com/javase/7/docs/api/java/net/URL.html#equals(java.lang.Object)) (at least I hope so):
> Two hosts are considered equivalent if both host names can be resolved into the same IP addresses; else if either host name can't be resolved, the host names must be equal without regard to case; or both host names equal to null.
