### PR TITLE
Remove "maven.pkg.jetbrains.space/public/p/compose/dev"

### DIFF
--- a/dokka-integration-tests/gradle/projects/it-android-compose/settings.gradle.kts
+++ b/dokka-integration-tests/gradle/projects/it-android-compose/settings.gradle.kts
@@ -15,10 +15,6 @@ dependencyResolutionManagement {
         /* %{DOKKA_IT_MAVEN_REPO}% */
         mavenCentral()
         google()
-        maven("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/public/p/compose/dev") {
-            name = "JetBrainsComposeDev"
-            // required for org.jetbrains.compose.compiler:compiler:1.5.15
-        }
     }
 }
 

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
@@ -206,6 +206,10 @@ fun interface TestedVersionsSource<T : TestedVersions> {
                     )
                 }
             }
+        }.filter {
+            // there is no anymore compose compiler dependency for KGP 1.9.25
+            // previously it was available only in maven.pkg.jetbrains.space/public/p/compose/dev
+            it.kgp.major == 2
         }
     }
 }

--- a/dokka-integration-tests/gradle/src/test/kotlin/junit/TestedVersionsSourceTest.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/junit/TestedVersionsSourceTest.kt
@@ -100,7 +100,7 @@ class TestedVersionsSourceTest {
                 agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2, 9.0.0
                 composeGradlePlugin: 1.7.0
                 gradle: 7.6.4, 8.14.3, 9.2.1
-                kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.0
+                kgp: 2.0.21, 2.1.21, 2.2.21, 2.3.0
                 """.trimIndent()
 
             Incompatible ->
@@ -108,7 +108,7 @@ class TestedVersionsSourceTest {
                 agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2
                 composeGradlePlugin: 1.7.0
                 gradle: 7.6.4, 8.14.3
-                kgp: 1.9.25, 2.0.21
+                kgp: 2.0.21
                 """.trimIndent()
         }
 


### PR DESCRIPTION
It doesn't contain "org.jetbrains.compose.compiler:compiler:1.5.15" anymore, so we can't really test compose with KGP 1.9

This fixed the currently failing IT on master ([example](https://teamcity.jetbrains.com/buildConfiguration/KotlinTools_Dokka_IntegrationTests/5906087)).