### PR TITLE
WIP: collect and assert which links are really missing in kotlinx projects

### DIFF
--- a/dokka-integration-tests/gradle/src/testExternalProjectKotlinxCoroutines/kotlin/CoroutinesGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testExternalProjectKotlinxCoroutines/kotlin/CoroutinesGradleIntegrationTest.kt
@@ -71,10 +71,174 @@ class CoroutinesGradleIntegrationTest : AbstractGradleIntegrationTest(), TestOut
         projectOutputLocation.allHtmlFiles().forEach { file ->
             assertContainsNoErrorClass(file)
             assertNoUnresolvedLinks(file)
-//            assertNoHrefToMissingLocalFileOrDirectory(file)
             assertNoEmptyLinks(file)
             assertNoEmptySpans(file)
             assertNoUnsubstitutedTemplatesInHtml(file)
         }
+
+        assertHrefMissing(
+            projectOutputLocation,
+            mapOf(
+                "kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-rx3/kotlinx.coroutines.rx3/-scheduler-coroutine-dispatcher/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-rx2/kotlinx.coroutines.rx2/-scheduler-coroutine-dispatcher/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-swing/kotlinx.coroutines.swing/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-swing/kotlinx.coroutines.swing/-swing-dispatcher/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-guava/kotlinx.coroutines.guava/as-listenable-future.html" to setOf(
+                    "../../kotlinx-coroutines-guava/kotlinx.coroutines.guava/-job-listenable-future/cancel.html" to "kotlinx-coroutines-guava/kotlinx.coroutines.guava/-job-listenable-future/cancel.html",
+                ),
+                "kotlinx-coroutines-slf4j/kotlinx.coroutines.slf4j/-m-d-c-context/index.html" to setOf(
+                    "../../../kotlinx-coroutines-slf4j/kotlinx.coroutines.slf4j/-m-d-c-context/--root--.html" to "kotlinx-coroutines-slf4j/kotlinx.coroutines.slf4j/-m-d-c-context/--root--.html",
+                ),
+                "kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit5/index.html" to setOf(
+                    "../../kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit5/-coroutines-timeout-extension/index.html" to "kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit5/-coroutines-timeout-extension/index.html",
+                ),
+                "kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit5/-coroutines-timeout/index.html" to setOf(
+                    "../../../kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit5/-coroutines-timeout-extension/index.html" to "kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit5/-coroutines-timeout-extension/index.html",
+                ),
+                "kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit4/-coroutines-timeout/index.html" to setOf(
+                    "../../../kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit4/-coroutines-timeout/cancel-on-timeout.html" to "kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit4/-coroutines-timeout/cancel-on-timeout.html",
+                    "../../../kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit4/-coroutines-timeout/enable-coroutine-creation-stack-traces.html" to "kotlinx-coroutines-debug/kotlinx.coroutines.debug.junit4/-coroutines-timeout/enable-coroutine-creation-stack-traces.html",
+                ),
+                "kotlinx-coroutines-javafx/kotlinx.coroutines.javafx/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-javafx/kotlinx.coroutines.javafx/-java-fx-dispatcher/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-reactor/kotlinx.coroutines.reactor/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html",
+                ),
+                "kotlinx-coroutines-reactor/kotlinx.coroutines.reactor/flux.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html",
+                ),
+                "kotlinx-coroutines-reactor/kotlinx.coroutines.reactor/-scheduler-coroutine-dispatcher/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-jdk9/kotlinx.coroutines.jdk9/flow-publish.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html",
+                ),
+                "kotlinx-coroutines-reactive/kotlinx.coroutines.reactive/publish.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html",
+                ),
+                "kotlinx-coroutines-android/kotlinx.coroutines.android/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-android/kotlinx.coroutines.android/-handler-dispatcher/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                ),
+                "kotlinx-coroutines-test/kotlinx.coroutines.test/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines/-delay-with-timeout-diagnostics/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay-with-timeout-diagnostics/index.html",
+                ),
+                "kotlinx-coroutines-test/kotlinx.coroutines.test/-test-dispatcher/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay/index.html",
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-delay-with-timeout-diagnostics/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-delay-with-timeout-diagnostics/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/-factory/-c-o-n-f-l-a-t-e-d.html" to setOf(
+                    "../../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/send.html",
+                    "../../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/try-send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/try-send.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/-factory/-r-e-n-d-e-z-v-o-u-s.html" to setOf(
+                    "../../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/send.html",
+                    "../../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/receive.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/receive.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/consume-each.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/-actor-scope/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-actor-scope/receive.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-actor-scope/receive.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/-actor-scope/channel.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-actor-scope/receive.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-actor-scope/receive.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/channel.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-producer-scope/send.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel-result/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/try-send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/try-send.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/try-send-blocking.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/send.html",
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel-result/-companion/failed.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel-result/-companion/failed.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.channels/consume.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.flow/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.flow/-cancellable-flow/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.flow/-cancellable-flow/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.flow/-state-flow/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-conflated-broadcast-channel/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-conflated-broadcast-channel/index.html",
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-conflated-broadcast-channel/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-conflated-broadcast-channel/send.html",
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-conflated-broadcast-channel/try-send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-conflated-broadcast-channel/try-send.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-shared-flow/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-shared-flow/replay-cache.html" to "kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-shared-flow/replay-cache.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-shared-flow/reset-replay-cache.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-shared-flow/replay-cache.html" to "kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-shared-flow/replay-cache.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.flow/receive-as-flow.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/receive.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-channel/receive.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.flow/-shared-flow/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/index.html",
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/send.html",
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/try-send.html" to "kotlinx-coroutines-core/kotlinx.coroutines.channels/-broadcast-channel/try-send.html",
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow/emit.html" to "kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow/emit.html",
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow/try-emit.html" to "kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow/try-emit.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow/emit.html" to "kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow/emit.html",
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow/try-emit.html" to "kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow/try-emit.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.flow/-abstract-flow/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.flow/-cancellable-flow/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.flow/-cancellable-flow/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines/-completion-handler/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-completion-handler-exception/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-completion-handler-exception/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines/-copyable-thread-context-element/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-copyable-thread-context-element/restore-thread-context.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-copyable-thread-context-element/restore-thread-context.html",
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-copyable-thread-context-element/update-thread-context.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-copyable-thread-context-element/update-thread-context.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines/-job/invoke-on-completion.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines/-completion-handler-exception/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines/-completion-handler-exception/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.selects/index.html" to setOf(
+                    "../../kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause1/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause0/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause/index.html",
+                ),
+                "kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause2/index.html" to setOf(
+                    "../../../kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause/index.html" to "kotlinx-coroutines-core/kotlinx.coroutines.selects/-select-clause/index.html",
+                ),
+            )
+        )
     }
 }

--- a/dokka-integration-tests/gradle/src/testExternalProjectKotlinxDatetime/kotlin/DatetimeGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testExternalProjectKotlinxDatetime/kotlin/DatetimeGradleIntegrationTest.kt
@@ -68,9 +68,157 @@ class DatetimeGradleIntegrationTest : AbstractGradleIntegrationTest(), TestOutpu
         projectOutputLocation.allHtmlFiles().forEach { file ->
             assertContainsNoErrorClass(file)
             assertNoUnresolvedLinks(file)
-            // assertNoHrefToMissingLocalFileOrDirectory(file)
             assertNoEmptyLinks(file)
             assertNoEmptySpans(file)
         }
+
+        // skipped deprecated declarations - https://github.com/Kotlin/dokka/issues/4448
+        // constructor parameters (--root--.html) -
+        // internal declarations in annotations - https://github.com/Kotlin/dokka/issues/4448
+        assertHrefMissing(
+            projectOutputLocation,
+            mapOf(
+                "kotlinx-datetime/kotlinx.datetime.format/-date-time-components/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime.format/-date-time-components/to-instant-using-offset.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-instant-serializer/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-formatted-instant-serializer/format.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-instant-serializer/format.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-formatted-instant-serializer/--root--.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-instant-serializer/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-local-date-time-serializer/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-formatted-local-date-time-serializer/--root--.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-local-date-time-serializer/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-year-month-serializer/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-formatted-year-month-serializer/--root--.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-year-month-serializer/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-utc-offset-serializer/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-formatted-utc-offset-serializer/--root--.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-utc-offset-serializer/--root--.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-utc-offset-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-utc-offset-serializer/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-local-time-serializer/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-formatted-local-time-serializer/--root--.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-local-time-serializer/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-local-date-serializer/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-formatted-local-date-serializer/--root--.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-formatted-local-date-serializer/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/to-j-s-date.html" to setOf(
+                    "../../kotlinx-datetime/kotlinx.datetime/-instant/index.html" to "kotlinx-datetime/kotlinx.datetime/-instant/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/at-start-of-day-in.html" to setOf(
+                    "../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/to-deprecated-clock.html" to setOf(
+                    "../../kotlinx-datetime/kotlinx.datetime/-clock/index.html" to "kotlinx-datetime/kotlinx.datetime/-clock/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-date-time-period/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-date-time-period-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-date-time-period-serializer/index.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/plus.html" to "kotlinx-datetime/kotlinx.datetime/-instant/plus.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-date-period/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-date-period-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-date-period-serializer/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-date-period/-date-period.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-date-period/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-date-period/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/to-stdlib-instant.html" to setOf(
+                    "../../kotlinx-datetime/kotlinx.datetime/-instant/index.html" to "kotlinx-datetime/kotlinx.datetime/-instant/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/index.html" to setOf(
+                    "../../kotlinx-datetime/kotlinx.datetime.serializers/-date-period-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-date-period-serializer/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime.serializers/-date-time-period-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-date-time-period-serializer/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime.serializers/-local-date-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-local-date-serializer/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime.serializers/-local-date-time-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-local-date-time-serializer/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime.serializers/-local-time-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-local-time-serializer/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime.serializers/-utc-offset-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-utc-offset-serializer/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime.serializers/-year-month-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-year-month-serializer/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime/-clock/index.html" to "kotlinx-datetime/kotlinx.datetime/-clock/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime/-instant/index.html" to "kotlinx-datetime/kotlinx.datetime/-instant/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/to-stdlib-clock.html" to setOf(
+                    "../../kotlinx-datetime/kotlinx.datetime/-clock/index.html" to "kotlinx-datetime/kotlinx.datetime/-clock/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-local-date/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-local-date-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-local-date-serializer/index.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-local-date/-local-date.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-local-date/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-local-date/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-utc-offset/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-utc-offset-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-utc-offset-serializer/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-year-month/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-year-month-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-year-month-serializer/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-year-month/-year-month.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-year-month/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-year-month/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-local-iso-week-date/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-p-a-s-t.html" to "kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-p-a-s-t.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-f-u-t-u-r-e.html" to "kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-f-u-t-u-r-e.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-local-iso-week-date/iso-week-number.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-local-iso-week-date/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-local-iso-week-date/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-local-iso-week-date/-local-iso-week-date.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-local-iso-week-date/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-local-iso-week-date/--root--.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-p-a-s-t.html" to "kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-p-a-s-t.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-f-u-t-u-r-e.html" to "kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-f-u-t-u-r-e.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/to-deprecated-instant.html" to setOf(
+                    "../../kotlinx-datetime/kotlinx.datetime/-instant/index.html" to "kotlinx-datetime/kotlinx.datetime/-instant/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-local-date-time/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-local-date-time-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-local-date-time-serializer/index.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-p-a-s-t.html" to "kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-p-a-s-t.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-f-u-t-u-r-e.html" to "kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-f-u-t-u-r-e.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-local-date-time/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-local-date-time/--root--.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-local-date-time/-local-date-time.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-local-date-time/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-local-date-time/--root--.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-p-a-s-t.html" to "kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-p-a-s-t.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-f-u-t-u-r-e.html" to "kotlinx-datetime/kotlinx.datetime/-instant/-companion/-d-i-s-t-a-n-t_-f-u-t-u-r-e.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-local-date-time/month-number.html" to "kotlinx-datetime/kotlinx.datetime/-local-date-time/month-number.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/to-instant.html" to setOf(
+                    "../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-time-zone/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-time-zone/to-instant.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-fixed-offset-time-zone/-fixed-offset-time-zone.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-fixed-offset-time-zone/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-fixed-offset-time-zone/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-fixed-offset-time-zone/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-fixed-offset-time-zone/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-fixed-offset-time-zone/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/to-kotlin-instant.html" to setOf(
+                    "../../kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html" to "kotlinx-datetime/kotlinx.datetime/-overload-marker/index.html",
+                    "../../kotlinx-datetime/kotlinx.datetime/-instant/index.html" to "kotlinx-datetime/kotlinx.datetime/-instant/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-local-time/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime.serializers/-local-time-serializer/index.html" to "kotlinx-datetime/kotlinx.datetime.serializers/-local-time-serializer/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-local-time/-local-time.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-local-time/--root--.html" to "kotlinx-datetime/kotlinx.datetime/-local-time/--root--.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-date-time-unit/index.html" to setOf(
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/plus.html" to "kotlinx-datetime/kotlinx.datetime/-instant/plus.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/minus.html" to "kotlinx-datetime/kotlinx.datetime/-instant/minus.html",
+                    "../../../kotlinx-datetime/kotlinx.datetime/-instant/index.html" to "kotlinx-datetime/kotlinx.datetime/-instant/index.html",
+                ),
+                "kotlinx-datetime/kotlinx.datetime/-date-time-unit/-date-based/index.html" to setOf(
+                    "../../../../kotlinx-datetime/kotlinx.datetime/-instant/index.html" to "kotlinx-datetime/kotlinx.datetime/-instant/index.html",
+                ),
+            )
+        )
     }
 }

--- a/dokka-integration-tests/gradle/src/testExternalProjectKotlinxIo/kotlin/IoGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testExternalProjectKotlinxIo/kotlin/IoGradleIntegrationTest.kt
@@ -73,9 +73,21 @@ class IoGradleIntegrationTest : AbstractGradleIntegrationTest(), TestOutputCopie
         projectOutputLocation.allHtmlFiles().forEach { file ->
             assertContainsNoErrorClass(file)
             assertNoUnresolvedLinks(file)
-            // assertNoHrefToMissingLocalFileOrDirectory(file)
             assertNoEmptyLinks(file)
             assertNoEmptySpans(file)
         }
+
+        assertHrefMissing(
+            output = projectOutputLocation,
+            // missing links to constructor parameters - https://github.com/Kotlin/dokka/issues/4328
+            expected = mapOf(
+                "kotlinx-io-bytestring/kotlinx.io.bytestring/-byte-string/index.html" to setOf(
+                    "../../../kotlinx-io-bytestring/kotlinx.io.bytestring/-byte-string/--root--.html" to "kotlinx-io-bytestring/kotlinx.io.bytestring/-byte-string/--root--.html",
+                ),
+                "kotlinx-io-bytestring/kotlinx.io.bytestring/-byte-string/-byte-string.html" to setOf(
+                    "../../../kotlinx-io-bytestring/kotlinx.io.bytestring/-byte-string/--root--.html" to "kotlinx-io-bytestring/kotlinx.io.bytestring/-byte-string/--root--.html",
+                ),
+            )
+        )
     }
 }

--- a/dokka-integration-tests/gradle/src/testExternalProjectKotlinxSerialization/kotlin/SerializationGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testExternalProjectKotlinxSerialization/kotlin/SerializationGradleIntegrationTest.kt
@@ -65,9 +65,111 @@ class SerializationGradleIntegrationTest : AbstractGradleIntegrationTest(), Test
         projectOutputLocation.allHtmlFiles().forEach { file ->
             assertContainsNoErrorClass(file)
             assertNoUnresolvedLinks(file)
-//            assertNoHrefToMissingLocalFileOrDirectory(file)
             assertNoEmptyLinks(file)
             assertNoEmptySpans(file)
         }
+
+        // skipped deprecated declarations - https://github.com/Kotlin/dokka/issues/4448
+        // protected declarations are not included, like in JsonTransformingSerializer.transformDeserialize
+        // constructor parameters (--root--.html) - https://github.com/Kotlin/dokka/issues/4328
+        // internal declarations in annotations - https://github.com/Kotlin/dokka/issues/4448
+        assertHrefMissing(
+            output = projectOutputLocation,
+            expected = mapOf(
+                "kotlinx-serialization-protobuf/kotlinx.serialization.protobuf/index.html" to setOf(
+                    "../../kotlinx-serialization-protobuf/kotlinx.serialization.protobuf/-proto-buf/--root--.html" to "kotlinx-serialization-protobuf/kotlinx.serialization.protobuf/-proto-buf/--root--.html",
+                ),
+                "kotlinx-serialization-protobuf/kotlinx.serialization.protobuf/-proto-buf/index.html" to setOf(
+                    "../../../kotlinx-serialization-protobuf/kotlinx.serialization.protobuf/-proto-buf/--root--.html" to "kotlinx-serialization-protobuf/kotlinx.serialization.protobuf/-proto-buf/--root--.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-array/index.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-array-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-array-serializer/index.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/index.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/select-deserializer.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/select-deserializer.html",
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/base-class.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/base-class.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/descriptor.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/base-class.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/base-class.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/index.html" to setOf(
+                    "../../kotlinx-serialization-json/kotlinx.serialization.json/-json-array-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-array-serializer/index.html",
+                    "../../kotlinx-serialization-json/kotlinx.serialization.json/-json-element-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-element-serializer/index.html",
+                    "../../kotlinx-serialization-json/kotlinx.serialization.json/-json-null-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-null-serializer/index.html",
+                    "../../kotlinx-serialization-json/kotlinx.serialization.json/-json-object-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-object-serializer/index.html",
+                    "../../kotlinx-serialization-json/kotlinx.serialization.json/-json-primitive-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-primitive-serializer/index.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-object/index.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-object-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-object-serializer/index.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-decoder/index.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html" to "kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-decoder/decode-json-element.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html" to "kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-element/index.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-element-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-element-serializer/index.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-null/index.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-null-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-null-serializer/index.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-primitive/index.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-primitive-serializer/index.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-primitive-serializer/index.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/index.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/transform-serialize.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/transform-serialize.html",
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/transform-deserialize.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/transform-deserialize.html",
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/t-serializer.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/t-serializer.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/descriptor.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/t-serializer.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/t-serializer.html",
+                ),
+                "kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/-json-transforming-serializer.html" to setOf(
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/transform-serialize.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/transform-serialize.html",
+                    "../../../kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/transform-deserialize.html" to "kotlinx-serialization-json/kotlinx.serialization.json/-json-transforming-serializer/transform-deserialize.html",
+                ),
+                "kotlinx-serialization-cbor/kotlinx.serialization.cbor/index.html" to setOf(
+                    "../../kotlinx-serialization-core/kotlinx.serialization/-k-serializer/deserialize.html" to "kotlinx-serialization-core/kotlinx.serialization/-k-serializer/deserialize.html",
+                    "../../kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html" to "kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html",
+                ),
+                "kotlinx-serialization-cbor/kotlinx.serialization.cbor/-cbor-encoder/index.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html" to "kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html",
+                ),
+                "kotlinx-serialization-cbor/kotlinx.serialization.cbor/-cbor-decoder/index.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-k-serializer/deserialize.html" to "kotlinx-serialization-core/kotlinx.serialization/-k-serializer/deserialize.html",
+                ),
+                "kotlinx-serialization-core/kotlinx.serialization.modules/index.html" to setOf(
+                    "../../kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-class.html" to "kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-class.html",
+                    "../../kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-serializer.html" to "kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-serializer.html",
+                ),
+                "kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/default-deserializer.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-class.html" to "kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-class.html",
+                ),
+                "kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/index.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-class.html" to "kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-class.html",
+                    "../../../kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-serializer.html" to "kotlinx-serialization-core/kotlinx.serialization.modules/-polymorphic-module-builder/base-serializer.html",
+                ),
+                "kotlinx-serialization-core/kotlinx.serialization.modules/plus.html" to setOf(
+                    "../../kotlinx-serialization-core/kotlinx.serialization.modules/-serializer-already-registered-exception/index.html" to "kotlinx-serialization-core/kotlinx.serialization.modules/-serializer-already-registered-exception/index.html",
+                ),
+                "kotlinx-serialization-core/kotlinx.serialization/-serialization-exception/index.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-serialization-exception/--root--.html" to "kotlinx-serialization-core/kotlinx.serialization/-serialization-exception/--root--.html",
+                ),
+                "kotlinx-serialization-core/kotlinx.serialization/-serialization-exception/-serialization-exception.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-serialization-exception/--root--.html" to "kotlinx-serialization-core/kotlinx.serialization/-serialization-exception/--root--.html",
+                ),
+                "kotlinx-serialization-core/kotlinx.serialization/-k-serializer/index.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html" to "kotlinx-serialization-core/kotlinx.serialization/-k-serializer/serialize.html",
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-k-serializer/deserialize.html" to "kotlinx-serialization-core/kotlinx.serialization/-k-serializer/deserialize.html",
+                ),
+                "kotlinx-serialization-core/kotlinx.serialization/-missing-field-exception/index.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-missing-field-exception/--root--.html" to "kotlinx-serialization-core/kotlinx.serialization/-missing-field-exception/--root--.html",
+                ),
+                "kotlinx-serialization-core/kotlinx.serialization/-missing-field-exception/-missing-field-exception.html" to setOf(
+                    "../../../kotlinx-serialization-core/kotlinx.serialization/-missing-field-exception/--root--.html" to "kotlinx-serialization-core/kotlinx.serialization/-missing-field-exception/--root--.html",
+                ),
+            )
+        )
     }
 }

--- a/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/AbstractIntegrationTest.kt
+++ b/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/AbstractIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.jsoup.Jsoup
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.net.URL
+import kotlin.io.relativeTo
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -59,6 +60,24 @@ abstract class AbstractIntegrationTest {
     protected fun assertNoHrefToMissingLocalFileOrDirectory(
         file: File, fileExtensions: Set<String> = setOf("html")
     ) {
+        val errors = collectHrefToMissingLocalFileOrDirectory(file, fileExtensions)
+        if (errors.isEmpty()) return
+
+        val errorMessage = buildString {
+            appendLine("Missing hrefs in ${file.relativeTo(projectDir).path}:")
+            errors.forEach { (href, targetFile) ->
+                appendLine("  href=\"$href\"")
+                appendLine("  target=${targetFile.relativeTo(projectDir).path}")
+            }
+        }
+        throw AssertionError(errorMessage)
+    }
+
+    private fun collectHrefToMissingLocalFileOrDirectory(
+        file: File,
+        fileExtensions: Set<String> = setOf("html"),
+    ): Set<Pair<String, File>> {
+        val errors = mutableSetOf<Pair<String, File>>()
         val fileText = file.readText()
         val html = Jsoup.parse(fileText)
         html.allElements.toList().forEach { element ->
@@ -81,13 +100,42 @@ abstract class AbstractIntegrationTest {
             if (targetFile.extension.isNotEmpty() && targetFile.extension !in fileExtensions) return@forEach
 
             if (targetFile.extension.isEmpty() || targetFile.extension == "html" && !href.startsWith("#")) {
-                assertTrue(
-                    targetFile.exists(),
-                    "${file.relativeTo(projectDir).path}: href=\"$href\"\n" +
-                            "file does not exist: ${targetFile.path}"
-                )
+                if (!targetFile.exists()) {
+                    errors.add(href to targetFile)
+                }
             }
         }
+        return errors
+    }
+
+    protected fun assertHrefMissing(
+        output: File,
+        expected: Map<String, Set<Pair<String, String>>> = emptyMap()
+    ) {
+        val errors = output.allHtmlFiles().mapNotNull { file ->
+            val errors = collectHrefToMissingLocalFileOrDirectory(file)
+            if (errors.isEmpty()) null else file to errors
+        }.toList()
+        if (errors.isEmpty()) return
+        val relativeErrors = errors.associate { (file, fileErrors) ->
+            file.relativeTo(output).path to fileErrors.mapTo(mutableSetOf()) { (href, targetFile) ->
+                href to targetFile.relativeTo(output).path
+            }
+        }
+
+        fun Map<String, Set<Pair<String, String>>>.printAsKotlinMap(): String = buildString {
+            appendLine("mapOf(")
+            this@printAsKotlinMap.forEach { (file, errors) ->
+                appendLine("  \"$file\" to setOf(")
+                errors.forEach { (href, targetFile) ->
+                    appendLine("    \"$href\" to \"$targetFile\",")
+                }
+                appendLine("  ),")
+            }
+            appendLine(")")
+        }
+
+        assertEquals(expected.printAsKotlinMap(), relativeErrors.printAsKotlinMap(), "Missing links")
     }
 
     protected fun assertNoSuppressedMarker(file: File) {


### PR DESCRIPTION
This is just an exploration that collects unresolved links in one place and shows which links Dokka generates in kotlinx projects.

Reasons:
- https://github.com/Kotlin/dokka/issues/4448
    - skipped deprecated declarations via `skipDeprecated = true`
    - internal declarations in annotations
- https://github.com/Kotlin/dokka/issues/4328
    - constructor parameters (links ending in --root--.html)
- https://github.com/Kotlin/dokka/issues/4201
    - documentedVisibilities includes only `Public` by [default](https://github.com/Kotlin/dokka/blob/bf3b5eea8fb6ec50d43420c13e44f5a83fdc4a77/dokka-runners/dokka-gradle-plugin/src/main/kotlin/DokkaBasePlugin.kt#L196)
    - links to protected declarations, like to [JsonTransformingSerializer.transformDeserialize](https://github.com/Kotlin/kotlinx.serialization/blob/c49dc47fbc3c9f2d2cbf42cd2a3876a1337c88bf/formats/json/commonMain/src/kotlinx/serialization/json/JsonTransformingSerializer.kt#L89)