### PR TITLE
Drop flag and separate test task for the new KDoc resolution

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild.test-integration.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.test-integration.gradle.kts
@@ -39,10 +39,6 @@ tasks.withType<Test>().configureEach {
     systemProperty.inputProperty("org.jetbrains.dokka.experimental.tryK2", useK2)
         .optional(true)
 
-    val enableExperimentalKDocResolution = dokkaBuild.integrationTestEnableExperimentalKDocResolution
-    systemProperty.inputProperty("org.jetbrains.dokka.analysis.enableExperimentalKDocResolution", enableExperimentalKDocResolution)
-        .optional(true)
-
     useJUnitPlatform {
         if (useK2.get()) excludeTags("onlyDescriptors", "onlyDescriptorsMPP")
     }

--- a/build-logic/src/main/kotlin/dokkabuild.test-k2.gradle.kts
+++ b/build-logic/src/main/kotlin/dokkabuild.test-k2.gradle.kts
@@ -47,13 +47,12 @@ testing {
             // JUnit tags for descriptors (K1) and symbols (K2) are defined with annotations in test classes.
             val onlyDescriptorTags = listOf("onlyDescriptors", "onlyDescriptorsMPP")
             val onlySymbolsTags = listOf("onlySymbols")
-            val onlyNewKdocResolutionTags = listOf("onlyNewKDocResolution")
             val onlyJavaPsiTags = listOf("onlyJavaPsi")
 
             // Create a new target for _only_ running test compatible with descriptor-analysis (K1).
             val testDescriptorsTarget = targets.register("testDescriptors") {
                 testTask.configure {
-                    val excludedTags = onlySymbolsTags + onlyNewKdocResolutionTags
+                    val excludedTags = onlySymbolsTags
                     description = "Runs tests using descriptors-analysis (K1) (excluding tags: ${excludedTags})"
                     useJUnitPlatform {
                         excludeTags.addAll(excludedTags)
@@ -67,7 +66,7 @@ testing {
             // Create a new target for _only_ running test compatible with symbols-analysis (K2).
             val testSymbolsTarget = targets.register("testSymbols") {
                 testTask.configure {
-                    val excludedTags = onlyDescriptorTags + onlyNewKdocResolutionTags
+                    val excludedTags = onlyDescriptorTags
                     description = "Runs tests using symbols-analysis (K2) (excluding tags: ${excludedTags})"
                     useJUnitPlatform {
                         excludeTags.addAll(excludedTags)
@@ -78,27 +77,10 @@ testing {
                 }
             }
 
-            // Create a new target for running symbols-analysis tests with enabled experimental KDoc resolution (K2).
-            val testSymbolsWithNewKDocResolutionTarget = targets.register("testSymbolsWithNewKDocResolution") {
-                testTask.configure {
-                    val excludedTags = onlyDescriptorTags
-                    description = "Runs tests using symbols-analysis and experimental KDoc resolution (K2)" +
-                            " (excluding tags: ${excludedTags})"
-                    useJUnitPlatform {
-                        excludeTags.addAll(excludedTags)
-                    }
-                    // Analysis dependencies from `symbolsTestImplementation` should precede all other dependencies
-                    // in order  to use the shadowed stdlib from the analysis dependencies
-                    classpath = symbolsTestImplementationResolver.incoming.files + classpath
-
-                    systemProperty("org.jetbrains.dokka.analysis.enableExperimentalKDocResolution", "true")
-                }
-            }
-
             // Create a new target for running tests with enabled experimental symbols java analysis.
             val testJavaSymbolsTarget = targets.register("testJavaSymbols") {
                 testTask.configure {
-                    val excludedTags = onlyDescriptorTags + onlyNewKdocResolutionTags + onlyJavaPsiTags
+                    val excludedTags = onlyDescriptorTags + onlyJavaPsiTags
                     description = "Runs tests using symbols-analysis (K2) for java (excluding tags: $excludedTags)"
                     useJUnitPlatform {
                         excludeTags.addAll(excludedTags)
@@ -120,7 +102,6 @@ testing {
                     onlyIf { false }
                     dependsOn(testDescriptorsTarget.map { it.testTask })
                     dependsOn(testSymbolsTarget.map { it.testTask })
-                    dependsOn(testSymbolsWithNewKDocResolutionTarget.map { it.testTask })
                     dependsOn(testJavaSymbolsTarget.map { it.testTask })
                 }
             }

--- a/build-logic/src/main/kotlin/dokkabuild/DokkaBuildProperties.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/DokkaBuildProperties.kt
@@ -86,11 +86,6 @@ abstract class DokkaBuildProperties @Inject constructor(
     val integrationTestDokkaVersionOverride: Provider<String> =
         dokkaProperty("integration_test.dokkaVersionOverride") { it }
 
-    /** Control whether integration tests should use the `org.jetbrains.dokka.analysis.enableExperimentalKDocResolution` flag. */
-    val integrationTestEnableExperimentalKDocResolution: Provider<Boolean> =
-        dokkaProperty("integration_test.enableExperimentalKDocResolution", String::toBoolean)
-            .orElse(false)
-
     val androidSdkDir: Provider<File> =
         providers
             // first try finding a local.properties file in any parent directory

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/AbstractGradleIntegrationTest.kt
@@ -112,7 +112,6 @@ abstract class AbstractGradleIntegrationTest : AbstractIntegrationTest() {
 
                     // property flag to use K2
                     add("-P${TestEnvironment.TRY_K2}=${TestEnvironment.shouldUseK2()}")
-                    add("-P${TestEnvironment.TRY_EXPERIMENTAL_KDOC_RESOLUTION}=${TestEnvironment.shouldUseExperimentalKDocResolution()}")
 
                     // Decrease Gradle daemon idle timeout to prevent old agents lingering on CI.
                     // A lower timeout means slower tests, which is preferred over OOMs and locked processes.

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestEnvironment.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestEnvironment.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Tag
 
 object TestEnvironment {
     const val TRY_K2: String = "org.jetbrains.dokka.experimental.tryK2"
-    const val TRY_EXPERIMENTAL_KDOC_RESOLUTION = "org.jetbrains.dokka.analysis.enableExperimentalKDocResolution"
 
     val isExhaustive: Boolean by systemProperty(String::toBoolean)
 
@@ -19,11 +18,6 @@ object TestEnvironment {
      * By default, it is disabled
      */
     fun shouldUseK2(): Boolean = getBooleanProperty(TRY_K2)
-
-    /**
-     * By default, it is disabled
-     */
-    fun shouldUseExperimentalKDocResolution(): Boolean = getBooleanProperty(TRY_EXPERIMENTAL_KDOC_RESOLUTION)
 
     private fun getBooleanProperty(propertyName: String): Boolean {
         return System.getProperty(propertyName) in setOf("1", "true")

--- a/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/TagsAnnotations.kt
+++ b/dokka-subprojects/analysis-kotlin-api/src/test/kotlin/org/jetbrains/dokka/analysis/test/TagsAnnotations.kt
@@ -60,19 +60,3 @@ annotation class OnlySymbols(val reason: String = "")
 @Tag("onlyDescriptorsMPP")
 annotation class OnlyDescriptorsMPP(val reason: String = "")
 
-/**
- * Run a test only for a new KDoc resolution (with K2)
- *
- * After we switch to the new KDoc resolution by default, this annotation should be removed
- */
-@Target(
-    AnnotationTarget.CLASS,
-    AnnotationTarget.FUNCTION,
-    AnnotationTarget.PROPERTY_GETTER,
-    AnnotationTarget.PROPERTY_SETTER
-)
-@Retention(
-    AnnotationRetention.RUNTIME
-)
-@Tag("onlyNewKDocResolution")
-annotation class OnlyNewKDocResolution(val reason: String = "")

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/InternalConfiguration.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/InternalConfiguration.kt
@@ -8,8 +8,6 @@ package org.jetbrains.dokka.analysis.kotlin.symbols.plugin
 internal object InternalConfiguration {
     private const val ALLOW_KOTLIN_PACKAGE_PROPERTY = "org.jetbrains.dokka.analysis.allowKotlinPackage"
 
-    private const val ENABLE_EXPERIMENTAL_KDOC_RESOLUTION = "org.jetbrains.dokka.analysis.enableExperimentalKDocResolution"
-
     private const val ENABLE_EXPERIMENTAL_SYMBOLS_JAVA_ANALYSIS = "org.jetbrains.dokka.analysis.enableExperimentalSymbolsJavaAnalysis"
 
     /**
@@ -21,14 +19,6 @@ internal object InternalConfiguration {
      */
     val allowKotlinPackage: Boolean
         get() = getBooleanProperty(ALLOW_KOTLIN_PACKAGE_PROPERTY)
-
-    /**
-     * Enable experimental KDoc resolution
-     *
-     * Default: false
-     */
-    val experimentalKDocResolutionEnabled: Boolean
-        get() = getBooleanProperty(ENABLE_EXPERIMENTAL_KDOC_RESOLUTION)
 
     /**
      * Enable java analysis using [DefaultSymbolToDocumentableTranslator][org.jetbrains.dokka.analysis.kotlin.symbols.translators.DefaultSymbolToDocumentableTranslator]

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/plugin/KotlinAnalysis.kt
@@ -76,10 +76,6 @@ internal fun createAnalysisSession(
     projectDisposable: Disposable = Disposer.newDisposable("StandaloneAnalysisAPISession.project"),
     isSampleProject: Boolean = false
 ): KotlinAnalysis {
-    if (InternalConfiguration.experimentalKDocResolutionEnabled) {
-        enableExperimentalKDocResolution()
-    }
-
     val sourcesModule = mutableMapOf<DokkaConfiguration.DokkaSourceSet, KaSourceModule>()
     val isMultiplatformProject = sourceSets.any { it.analysisPlatform != Platform.jvm }
 
@@ -195,11 +191,4 @@ internal fun topologicalSortByDependantSourceSets(
     }
     sourceSets.forEach(::dfs)
     return result
-}
-
-private fun enableExperimentalKDocResolution() {
-    // Enable experimental KDoc resolution in Kotlin Analysis API (K2)
-    @Suppress("UnstableApiUsage")
-    LoadingState.setCurrentState(LoadingState.COMPONENTS_LOADED)
-    System.setProperty("kotlin.analysis.experimentalKDocResolution", "true")
 }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/content/kdoc/KDocAmbiguityResolutionTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/content/kdoc/KDocAmbiguityResolutionTest.kt
@@ -27,12 +27,11 @@ import org.jetbrains.dokka.pages.ClasslikePageNode
 import org.jetbrains.dokka.pages.ContentDRILink
 import org.jetbrains.dokka.pages.ContentPage
 import org.jetbrains.dokka.pages.MemberPageNode
-import utils.OnlyNewKDocResolution
+import utils.OnlySymbols
 import utils.findTestType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OnlyNewKDocResolution("KEEP #389: New KDoc resolution")
 class KDocAmbiguityResolutionTest : BaseAbstractTest() {
     private val testConfiguration = dokkaConfiguration {
         sourceSets {
@@ -45,6 +44,7 @@ class KDocAmbiguityResolutionTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("KEEP #389: New KDoc resolution")
     fun `#3451 ambiguous link to the class`() {
         testInline(
             """
@@ -119,6 +119,7 @@ class KDocAmbiguityResolutionTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("KEEP #389: New KDoc resolution")
     fun `#3451 ambiguous link to function and property`() {
         testInline(
             """
@@ -211,6 +212,7 @@ class KDocAmbiguityResolutionTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("KEEP #389: New KDoc resolution")
     fun `#3451 ambiguous link with factory functions`() {
         testInline(
             """
@@ -358,6 +360,7 @@ class KDocAmbiguityResolutionTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("KEEP #389: New KDoc resolution")
     fun `#3451 ambiguous link to inner class`() {
         testInline(
             """
@@ -534,6 +537,7 @@ class KDocAmbiguityResolutionTest : BaseAbstractTest() {
 
 
     @Test
+    @OnlySymbols("KEEP #389: New KDoc resolution")
     fun `#3604 KDoc reference to class from constructor`() {
         testInline(
             """
@@ -664,6 +668,7 @@ class KDocAmbiguityResolutionTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("KEEP #389: New KDoc resolution")
     fun `#3632 KDoc reference to member in extension`() {
         testInline(
             """

--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
@@ -16,7 +16,6 @@ import org.jetbrains.dokka.pages.ClasslikePageNode
 import org.jetbrains.dokka.pages.ContentDRILink
 import org.jetbrains.dokka.pages.MemberPageNode
 import utils.OnlyDescriptors
-import utils.OnlyNewKDocResolution
 import utils.OnlySymbols
 import utils.text
 import kotlin.test.Test
@@ -613,7 +612,7 @@ class LinkTest : BaseAbstractTest() {
     }
 
     @Test
-    @OnlyNewKDocResolution("KEEP #389: New KDoc resolution")
+    @OnlySymbols("KEEP #389: New KDoc resolution")
     fun `fully qualified link should lead to function`() {
         // for the test case, there is the only one link candidate in K1 and K2
         testInline(
@@ -796,7 +795,7 @@ class LinkTest : BaseAbstractTest() {
     }
 
     @Test
-    @OnlyNewKDocResolution("KEEP #389: New KDoc resolution")
+    @OnlySymbols("KEEP #389: New KDoc resolution")
     fun `short link should lead to function`() {
         testInline(
             """

--- a/dokka-subprojects/plugin-base/src/test/kotlin/utils/TagsAnnotations.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/utils/TagsAnnotations.kt
@@ -60,23 +60,6 @@ annotation class OnlySymbols(val reason: String = "")
 annotation class OnlyDescriptorsMPP(val reason: String = "")
 
 /**
- * Run a test only for a new KDoc resolution (with K2)
- *
- * After we switch to the new KDoc resolution by default, this annotation should be removed
- */
-@Target(
-    AnnotationTarget.CLASS,
-    AnnotationTarget.FUNCTION,
-    AnnotationTarget.PROPERTY_GETTER,
-    AnnotationTarget.PROPERTY_SETTER
-)
-@Retention(
-    AnnotationRetention.RUNTIME
-)
-@Tag("onlyNewKDocResolution")
-annotation class OnlyNewKDocResolution(val reason: String = "")
-
-/**
  * Tests that pass with PSI-based Java analysis but fail with symbol-based Java analysis.
  */
 @Target(


### PR DESCRIPTION
New KDoc resolution is enabled by default as of Kotlin-AA 2.4.0-dev-1742 ([KT-83723](https://youtrack.jetbrains.com/issue/KT-83723) [Analysis API] Enable experimental KDoc resolver by default). And we are already using it after #4471 :)

In fact, it fixed most of the errors found in https://github.com/Kotlin/dokka/issues/4425#issuecomment-3785412875; the remaining ones are shown in [#4479 PR for kotlinx-io](https://github.com/Kotlin/dokka/pull/4479/changes#diff-1bb8938e35307178bb1cd26f36141b4d118abdf8383d5362be644e5e9972fe68) and are currently being investigated by @vmishenev.

Also, no new errors were introduced in our tests. Effectively, this should fix https://github.com/Kotlin/dokka/issues/4425 (with #4476 adding a unit test for a specific case)
WDYT?

I will drop the CI job after the PR is merged.
Note that because we configured our IT a bit incorrectly, we needed to pass the flag via system properties (in DGPv2 to the worker, in DGPv1 to the whole Gradle build), but we passed it just as a Gradle property (like with K2, for which we have a specific handling), so the flag really didn't affect the tests at all...
So before #4471 we run with new KDoc resolution **disabled**; after with **enabled** :)