### PR TITLE
Update `com.gradle.publish:plugin-publish-plugin` and declare Gradle CC compatibility

### DIFF
--- a/dokka-runners/dokka-gradle-plugin/build.gradle.kts
+++ b/dokka-runners/dokka-gradle-plugin/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import dokkabuild.tasks.GenerateDokkaGradlePluginConstants
 import dokkabuild.utils.skipTestFixturesPublications
+import org.gradle.plugin.compatibility.compatibility
 
 plugins {
     id("dokkabuild.gradle-plugin")
@@ -112,6 +113,11 @@ gradlePlugin {
             "api reference",
             "documentation",
         )
+        compatibility {
+            features {
+                configurationCache = true
+            }
+        }
     }
     plugins.register("dokkaHtml") {
         id = "org.jetbrains.dokka"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ node = "20.16.0"
 
 ## Publishing
 gradlePlugin-shadow = "8.3.0"
-gradlePlugin-gradlePluginPublish = "1.2.1"
+gradlePlugin-gradlePluginPublish = "2.1.1"
 gradlePlugin-gradleNode = "7.1.0"
 
 ## Gradle Develocity


### PR DESCRIPTION
Dokka was manually marked as CC compatible, so now to publish the new version, we need to declare this explicitly.

Related internal threads ([1](https://jetbrains.slack.com/archives/C02H0GSH474/p1774272321581819), [2](https://jetbrains.slack.com/archives/C05NTFCF9NV/p1774042299809459), [3](https://jetbrains.slack.com/archives/CDH5M7FAT/p1773254449183819))