### PR TITLE
Support Project Isolation in DGPv2

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/WithGradleProperties.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/WithGradleProperties.kt
@@ -40,4 +40,13 @@ fun interface GradlePropertiesProvider {
             put("android.useAndroidX", "true")
         }
     }
+
+    object AndroidCompose : GradlePropertiesProvider {
+        override fun get(): Map<String, String> = buildMap {
+            putAll(Android.get())
+            // compose plugin doesn't support project-iso
+            // https://youtrack.jetbrains.com/issue/CMP-7080 https://youtrack.jetbrains.com/issue/CMP-8375
+            put("org.gradle.unsafe.isolated-projects", "false")
+        }
+    }
 }

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/testTags.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/testTags.kt
@@ -83,7 +83,7 @@ annotation class TestsAndroid(
 @Target(FUNCTION, CLASS)
 @MustBeDocumented
 @Inherited
-@WithGradleProperties(GradlePropertiesProvider.Android::class)
+@WithGradleProperties(GradlePropertiesProvider.AndroidCompose::class)
 annotation class TestsAndroidCompose(
     val kotlinBuiltIn: KotlinBuiltInCompatibility = KotlinBuiltInCompatibility.Supported,
 )

--- a/dokka-integration-tests/gradle/src/testExampleProjects/kotlin/ExampleProjectsTest.kt
+++ b/dokka-integration-tests/gradle/src/testExampleProjects/kotlin/ExampleProjectsTest.kt
@@ -215,6 +215,9 @@ class ExampleProjectsTest {
                         // when generating on Linux machines, resulting in 'Error class: unknown class'
                         // for CoroutineScope appearing in the generated docs.
                         kotlin.native.enableKlibsCrossCompilation = true
+
+                        // KT-80311 Kotlin JS and Wasm do not support isolated projects
+                        gradle.isolatedProjects = false
                     }
                 }
 

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/GradlePropertiesFileSource.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/GradlePropertiesFileSource.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package org.jetbrains.dokka.gradle.internal
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import java.util.*
+
+/**
+ * Read `gradle.properties` files from the project directory.
+ *
+ * Workaround for [org.gradle.testfixtures.ProjectBuilder] not reading `gradle.properties` files.
+ */
+// TODO remove when updating Gradle to 9.4+
+//      https://github.com/gradle/gradle/issues/17638#issuecomment-4030001290
+internal abstract class GradlePropertiesFileSource :
+    ValueSource<Map<String, String?>, GradlePropertiesFileSource.Params> {
+
+    interface Params : ValueSourceParameters {
+        val projectDirectory: RegularFileProperty
+    }
+
+    override fun obtain(): Map<String, String?> {
+        val gpFile = parameters.projectDirectory.get().asFile
+            .resolve("gradle.properties")
+            .takeIf { it.exists() }
+            ?: return emptyMap()
+
+        val props = Properties()
+
+        gpFile.inputStream().use { reader ->
+            props.load(reader)
+        }
+
+        return props.entries.associate { it.key.toString() to it.value?.toString() }
+    }
+}

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/PluginFeaturesService.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/PluginFeaturesService.kt
@@ -330,9 +330,14 @@ constructor(
             // Note: Manually reading `gradle.properties is only required for unit tests.
             // (Because org.gradle.testfixtures.ProjectBuilder doesn't support mocking Gradle properties
             // in Gradle versions lower than 9.4.)
-            val gpProps = project.providers.of(GradlePropertiesFileSource::class) {
-                parameters.projectDirectory.set(project.layout.projectDirectory.asFile)
-            }
+            val gpProps: Provider<Map<String, String?>> =
+                if (CurrentGradleVersion < "9.4.0") {
+                    project.providers.of(GradlePropertiesFileSource::class) {
+                        parameters.projectDirectory.set(project.layout.projectDirectory.asFile)
+                    }
+                } else {
+                    project.providers.provider { emptyMap() }
+                }
 
             /** Find a flag for [PluginFeaturesService]. */
             fun getFlag(flag: String): Provider<String> =
@@ -495,13 +500,6 @@ private abstract class GradlePropertiesFileSource :
 
     interface Params : ValueSourceParameters {
         val projectDirectory: RegularFileProperty
-    }
-
-    init {
-        require(CurrentGradleVersion < "9.4.0") {
-            "GradlePropertiesFileSource is not needed anymore and can be deleted. " +
-                    "Gradle will read properties files in tests https://github.com/gradle/gradle/issues/17638#issuecomment-4030001290"
-        }
     }
 
     override fun obtain(): Map<String, String?> {

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/PluginFeaturesService.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/PluginFeaturesService.kt
@@ -7,12 +7,12 @@ import org.gradle.TaskExecutionRequest
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logging
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.*
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
+import org.gradle.kotlin.dsl.of
 import org.gradle.kotlin.dsl.provideDelegate
 import org.jetbrains.dokka.gradle.internal.PluginFeaturesService.Companion.PLUGIN_MODE_NO_WARN_FLAG
 import org.jetbrains.dokka.gradle.internal.PluginFeaturesService.Companion.configureParamsDuringAccessorsGeneration
@@ -327,17 +327,23 @@ constructor(
             project: Project
         ): Action<Params> {
 
+            // Note: Manually reading `gradle.properties is only required for unit tests.
+            // (Because org.gradle.testfixtures.ProjectBuilder doesn't support mocking Gradle properties
+            // in Gradle versions lower than 9.4.)
+            val gpProps = project.providers.of(GradlePropertiesFileSource::class) {
+                parameters.projectDirectory.set(project.layout.projectDirectory.asFile)
+            }
+
             /** Find a flag for [PluginFeaturesService]. */
             fun getFlag(flag: String): Provider<String> =
                 project.providers
                     .gradleProperty(flag)
                     .forUseAtConfigurationTimeCompat()
                     .orElse(
-                        // Note: Enabling/disabling features via extra-properties is only intended for unit tests.
-                        // (Because org.gradle.testfixtures.ProjectBuilder doesn't support mocking Gradle properties.
-                        // But maybe soon! https://github.com/gradle/gradle/pull/30002)
-                        project
-                            .provider { project.findProperty(flag)?.toString() }
+                        gpProps
+                            .flatMap {
+                                project.providers.provider { it[flag] }
+                            }
                             .forUseAtConfigurationTimeCompat()
                     )
 
@@ -475,4 +481,44 @@ private fun Project.findGradlePropertiesFile(): File? {
         .map { it.resolve("gradle.properties") }
 
         .firstOrNull { it.exists() && it.isFile }
+}
+
+/**
+ * Read `gradle.properties` files from the project directory.
+ *
+ * Workaround for [org.gradle.testfixtures.ProjectBuilder] not reading `gradle.properties` files.
+ */
+// TODO remove when updating Gradle to 9.4+
+//      https://github.com/gradle/gradle/issues/17638#issuecomment-4030001290
+private abstract class GradlePropertiesFileSource :
+    ValueSource<Map<String, String?>, GradlePropertiesFileSource.Params> {
+
+    interface Params : ValueSourceParameters {
+        val projectDirectory: RegularFileProperty
+    }
+
+    init {
+        require(CurrentGradleVersion < "9.4.0") {
+            "GradlePropertiesFileSource is not needed anymore and can be deleted. " +
+                    "Gradle will read properties files in tests https://github.com/gradle/gradle/issues/17638#issuecomment-4030001290"
+        }
+    }
+
+    override fun obtain(): Map<String, String?> {
+        val gpFile = parameters.projectDirectory.get().asFile
+            .resolve("gradle.properties")
+            .takeIf { it.exists() }
+
+        if (gpFile == null) {
+            return emptyMap()
+        }
+
+        val props = Properties()
+
+        gpFile.inputStream().use { reader ->
+            props.load(reader)
+        }
+
+        return props.entries.associate { it.key.toString() to it.value?.toString() }
+    }
 }

--- a/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/PluginFeaturesService.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/main/kotlin/internal/PluginFeaturesService.kt
@@ -7,9 +7,10 @@ import org.gradle.TaskExecutionRequest
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logging
-import org.gradle.api.provider.*
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.kotlin.dsl.of
@@ -486,37 +487,4 @@ private fun Project.findGradlePropertiesFile(): File? {
         .map { it.resolve("gradle.properties") }
 
         .firstOrNull { it.exists() && it.isFile }
-}
-
-/**
- * Read `gradle.properties` files from the project directory.
- *
- * Workaround for [org.gradle.testfixtures.ProjectBuilder] not reading `gradle.properties` files.
- */
-// TODO remove when updating Gradle to 9.4+
-//      https://github.com/gradle/gradle/issues/17638#issuecomment-4030001290
-private abstract class GradlePropertiesFileSource :
-    ValueSource<Map<String, String?>, GradlePropertiesFileSource.Params> {
-
-    interface Params : ValueSourceParameters {
-        val projectDirectory: RegularFileProperty
-    }
-
-    override fun obtain(): Map<String, String?> {
-        val gpFile = parameters.projectDirectory.get().asFile
-            .resolve("gradle.properties")
-            .takeIf { it.exists() }
-
-        if (gpFile == null) {
-            return emptyMap()
-        }
-
-        val props = Properties()
-
-        gpFile.inputStream().use { reader ->
-            props.load(reader)
-        }
-
-        return props.entries.associate { it.key.toString() to it.value?.toString() }
-    }
 }

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradleProjectUtils.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradleProjectUtils.kt
@@ -4,15 +4,16 @@
 package org.jetbrains.dokka.gradle.utils
 
 import org.gradle.api.Project
+import java.util.*
 
 fun Project.enableV1Plugin(
     noWarn: Boolean = true
 ): Project {
-    extensions.extraProperties.set(
-        "org.jetbrains.dokka.experimental.gradle.pluginMode",
-        "V1Enabled",
-    )
-    extensions.extraProperties.set("org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn", noWarn)
+    writeGradleProperties(project) {
+        dokka.pluginMode = "V1Enabled"
+        dokka.pluginModeNoWarn = noWarn
+    }
+
     return this
 }
 
@@ -20,10 +21,34 @@ fun Project.enableV2Plugin(
     v2MigrationHelpers: Boolean = true,
     noWarn: Boolean = true
 ): Project {
-    extensions.extraProperties.set(
-        "org.jetbrains.dokka.experimental.gradle.pluginMode",
-        if (v2MigrationHelpers) "V2EnabledWithHelpers" else "V2Enabled",
-    )
-    extensions.extraProperties.set("org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn", noWarn)
+    writeGradleProperties(project) {
+        dokka.pluginMode = if (v2MigrationHelpers) "V2EnabledWithHelpers" else "V2Enabled"
+        dokka.pluginModeNoWarn = noWarn
+    }
     return this
+}
+
+private fun writeGradleProperties(
+    project: Project,
+    config: GradlePropertiesBuilder.() -> Unit,
+) {
+    val file = project.projectDir.resolve("gradle.properties")
+    if (!file.exists()) {
+        file.parentFile.mkdirs()
+        file.createNewFile()
+    }
+
+    val properties = GradlePropertiesBuilder()
+        .apply(config)
+        .build()
+
+    val existingProperties = Properties().apply {
+        file.inputStream().use { load(it) }
+    }
+
+    existingProperties.putAll(properties)
+
+    file.outputStream().use {
+        existingProperties.store(it, null)
+    }
 }

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradlePropertiesBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradlePropertiesBuilder.kt
@@ -20,6 +20,11 @@ data class GradlePropertiesBuilder(
     fun gradle(config: GradleArgs.() -> Unit): Unit = gradle.config()
     fun kotlin(config: KotlinArgs.() -> Unit): Unit = kotlin.config()
 
+    init {
+        // TODO enable isolatedProjects by default when DGPv1 is removed
+        gradle.isolatedProjects = if (dokka.pluginMode == "V1Enabled") null else true
+    }
+
     /** Gradle specific options. */
     data class GradleArgs(
         var logLevel: LogLevel? = LogLevel.LIFECYCLE,
@@ -43,9 +48,10 @@ data class GradlePropertiesBuilder(
         var maxWorkers: Int? = null,
         val jvmArgs: JvmArgs = JvmArgs(),
 
+        var isolatedProjects: Boolean? = null,
+
         // Maybe also implement these flags? Although there's no suitable tests for them at present.
         // org.gradle.projectcachedir=(directory)
-        // org.gradle.unsafe.isolated-projects=(true,false)
         // org.gradle.vfs.verbose=(true,false)
         // org.gradle.vfs.watch=(true,false)
     ) {
@@ -128,6 +134,7 @@ data class GradlePropertiesBuilder(
             putNotNull("org.gradle.parallel", parallel)
             putNotNull("org.gradle.logging.stacktrace", stacktrace)
             putNotNull("org.gradle.warning.mode", warningMode)
+            putNotNull("org.gradle.unsafe.isolated-projects", isolatedProjects)
             jvmArgs.buildString().takeIf { it.isNotBlank() }?.let {
                 put("org.gradle.jvmargs", it)
             }

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradlePropertiesBuilder.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/GradlePropertiesBuilder.kt
@@ -21,7 +21,7 @@ data class GradlePropertiesBuilder(
     fun kotlin(config: KotlinArgs.() -> Unit): Unit = kotlin.config()
 
     init {
-        // TODO enable isolatedProjects by default when DGPv1 is removed
+        // TODO #4436 enable isolatedProjects by default when DGPv1 is removed
         gradle.isolatedProjects = if (dokka.pluginMode == "V1Enabled") null else true
     }
 

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/MultiModuleProject.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/MultiModuleProject.kt
@@ -20,8 +20,6 @@ fun TestScope.initMultiModuleProject(
         .substringAfter("org.jetbrains.dokka.gradle.") // drop the package name
         .replaceNonAlphaNumeric()
 
-    val kgpVersion = "2.3.0"
-
     return gradleKtsProjectTest(
         projectLocation = "$baseDirName/multi-module-hello-goodbye/$testName",
         rootProjectName = rootProjectName,
@@ -38,7 +36,7 @@ fun TestScope.initMultiModuleProject(
             |plugins {
             |  // Must apply KGP in the root project ensure consistent classpath, 
             |  // preventing issues like https://github.com/gradle/gradle/issues/17559 and https://github.com/gradle/gradle/issues/27218
-            |  kotlin("jvm") version "$kgpVersion" apply false
+            |  kotlin("jvm") version "$defaultKgpTestVersion" apply false
             |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
             |  id("org.jetbrains.dokka-javadoc") version "${DokkaConstants.DOKKA_VERSION}"
             |}
@@ -53,7 +51,7 @@ fun TestScope.initMultiModuleProject(
         dir("subproject-hello") {
             buildGradleKts = """
                 |plugins {
-                |  kotlin("jvm") version "$kgpVersion"
+                |  kotlin("jvm") version "$defaultKgpTestVersion"
                 |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
                 |  id("org.jetbrains.dokka-javadoc") version "${DokkaConstants.DOKKA_VERSION}"
                 |}
@@ -81,7 +79,7 @@ fun TestScope.initMultiModuleProject(
 
             buildGradleKts = """
                 |plugins {
-                |  kotlin("jvm") version "$kgpVersion"
+                |  kotlin("jvm") version "$defaultKgpTestVersion"
                 |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
                 |  id("org.jetbrains.dokka-javadoc") version "${DokkaConstants.DOKKA_VERSION}"
                 |}

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/MultiModuleProject.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/MultiModuleProject.kt
@@ -20,6 +20,8 @@ fun TestScope.initMultiModuleProject(
         .substringAfter("org.jetbrains.dokka.gradle.") // drop the package name
         .replaceNonAlphaNumeric()
 
+    val kgpVersion = "2.3.0"
+
     return gradleKtsProjectTest(
         projectLocation = "$baseDirName/multi-module-hello-goodbye/$testName",
         rootProjectName = rootProjectName,
@@ -36,7 +38,7 @@ fun TestScope.initMultiModuleProject(
             |plugins {
             |  // Must apply KGP in the root project ensure consistent classpath, 
             |  // preventing issues like https://github.com/gradle/gradle/issues/17559 and https://github.com/gradle/gradle/issues/27218
-            |  kotlin("jvm") version embeddedKotlinVersion apply false
+            |  kotlin("jvm") version "$kgpVersion" apply false
             |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
             |  id("org.jetbrains.dokka-javadoc") version "${DokkaConstants.DOKKA_VERSION}"
             |}
@@ -51,7 +53,7 @@ fun TestScope.initMultiModuleProject(
         dir("subproject-hello") {
             buildGradleKts = """
                 |plugins {
-                |  kotlin("jvm") version embeddedKotlinVersion
+                |  kotlin("jvm") version "$kgpVersion"
                 |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
                 |  id("org.jetbrains.dokka-javadoc") version "${DokkaConstants.DOKKA_VERSION}"
                 |}
@@ -79,7 +81,7 @@ fun TestScope.initMultiModuleProject(
 
             buildGradleKts = """
                 |plugins {
-                |  kotlin("jvm") version embeddedKotlinVersion
+                |  kotlin("jvm") version "$kgpVersion"
                 |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
                 |  id("org.jetbrains.dokka-javadoc") version "${DokkaConstants.DOKKA_VERSION}"
                 |}

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/NoConfigMultiModuleProject.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/NoConfigMultiModuleProject.kt
@@ -26,8 +26,6 @@ fun TestScope.initNoConfigMultiModuleProject(
         .substringAfter("org.jetbrains.dokka.gradle.") // drop the package name
         .replaceNonAlphaNumeric()
 
-    val kgpVersion = "2.3.0"
-
     return gradleKtsProjectTest(
         projectLocation = "$baseDirName/multi-module-hello-goodbye/$testName",
         rootProjectName = rootProjectName,
@@ -48,7 +46,7 @@ fun TestScope.initNoConfigMultiModuleProject(
 
         buildGradleKts = """
             |plugins {
-            |  kotlin("jvm") version "$kgpVersion" apply false
+            |  kotlin("jvm") version "$defaultKgpTestVersion" apply false
             |  // important: don't register Dokka in the root project, because we _want_ the test to trigger a
             |  // Gradle classloader bug.
             |  //id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
@@ -59,10 +57,10 @@ fun TestScope.initNoConfigMultiModuleProject(
         dir("subproject-one") {
             buildGradleKts = """
                 |plugins {
-                |  kotlin("jvm") version "$kgpVersion"
+                |  kotlin("jvm") version "$defaultKgpTestVersion"
                 |  // important: Register different plugins here to make the buildscript classpath different,
                 |  // because we _want_ the test to trigger a Gradle classloader bug.
-                |  kotlin("plugin.serialization") version "$kgpVersion"
+                |  kotlin("plugin.serialization") version "$defaultKgpTestVersion"
                 |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
                 |}
                 |
@@ -87,7 +85,7 @@ fun TestScope.initNoConfigMultiModuleProject(
 
             buildGradleKts = """
                 |plugins {
-                |  kotlin("jvm") version "$kgpVersion"
+                |  kotlin("jvm") version "$defaultKgpTestVersion"
                 |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
                 |}
                 |

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/NoConfigMultiModuleProject.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/NoConfigMultiModuleProject.kt
@@ -26,6 +26,8 @@ fun TestScope.initNoConfigMultiModuleProject(
         .substringAfter("org.jetbrains.dokka.gradle.") // drop the package name
         .replaceNonAlphaNumeric()
 
+    val kgpVersion = "2.3.0"
+
     return gradleKtsProjectTest(
         projectLocation = "$baseDirName/multi-module-hello-goodbye/$testName",
         rootProjectName = rootProjectName,
@@ -46,7 +48,7 @@ fun TestScope.initNoConfigMultiModuleProject(
 
         buildGradleKts = """
             |plugins {
-            |  kotlin("jvm") version embeddedKotlinVersion apply false
+            |  kotlin("jvm") version "$kgpVersion" apply false
             |  // important: don't register Dokka in the root project, because we _want_ the test to trigger a
             |  // Gradle classloader bug.
             |  //id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
@@ -57,10 +59,10 @@ fun TestScope.initNoConfigMultiModuleProject(
         dir("subproject-one") {
             buildGradleKts = """
                 |plugins {
-                |  kotlin("jvm") version embeddedKotlinVersion
+                |  kotlin("jvm") version "$kgpVersion"
                 |  // important: Register different plugins here to make the buildscript classpath different,
                 |  // because we _want_ the test to trigger a Gradle classloader bug.
-                |  kotlin("plugin.serialization") version embeddedKotlinVersion
+                |  kotlin("plugin.serialization") version "$kgpVersion"
                 |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
                 |}
                 |
@@ -85,7 +87,7 @@ fun TestScope.initNoConfigMultiModuleProject(
 
             buildGradleKts = """
                 |plugins {
-                |  kotlin("jvm") version embeddedKotlinVersion
+                |  kotlin("jvm") version "$kgpVersion"
                 |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
                 |}
                 |

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/versions.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/versions.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2014-2026 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package org.jetbrains.dokka.gradle.utils.projects
+
+/**
+ * Default version of Kotlin Gradle Plugin used in functional tests.
+ *
+ * The KGP version does not usually need to be dynamic for DGP functional tests,
+ * since DPG functional behaviour should not depend on the KGP version.
+ * Tests that run against different KGP versions are in the `dokka-integration-tests` project.
+ */
+// Must use KGP >= 2.3.0:
+// - to avoid KT-77988
+// - to test `generatedKotlin` API
+const val defaultKgpTestVersion = "2.3.0"

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaDependenciesCompatibilityTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaDependenciesCompatibilityTest.kt
@@ -7,6 +7,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.string.shouldNotBeBlank
 import org.jetbrains.dokka.gradle.internal.DokkaConstants.DOKKA_VERSION
 import org.jetbrains.dokka.gradle.utils.*
+import org.jetbrains.dokka.gradle.utils.projects.defaultKgpTestVersion
 
 /**
  * Test Dokka creates Configurations that do not interfere with
@@ -15,13 +16,7 @@ import org.jetbrains.dokka.gradle.utils.*
 class DokkaDependenciesCompatibilityTest : FunSpec({
     context("verify that DGP does not interfere with resolving JAR Configurations") {
 
-        val project = initProject {
-            gradleProperties {
-                gradle.configurationCache = false
-                gradle.isolatedProjects = false
-                gradle.buildCache = false
-            }
-        }
+        val project = initProject()
 
         project.runner
             .addArguments(
@@ -69,7 +64,7 @@ private fun initProject(
         dir("subproject-with-dokka") {
             buildGradleKts = """
                 |plugins {
-                |  kotlin("multiplatform") version embeddedKotlinVersion
+                |  kotlin("multiplatform") version "$defaultKgpTestVersion"
                 |  id("org.jetbrains.dokka") version "$DOKKA_VERSION"
                 |}
                 |

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaDependenciesCompatibilityTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaDependenciesCompatibilityTest.kt
@@ -15,14 +15,19 @@ import org.jetbrains.dokka.gradle.utils.*
 class DokkaDependenciesCompatibilityTest : FunSpec({
     context("verify that DGP does not interfere with resolving JAR Configurations") {
 
-        val project = initProject()
+        val project = initProject {
+            gradleProperties {
+                gradle.configurationCache = false
+                gradle.isolatedProjects = false
+                gradle.buildCache = false
+            }
+        }
 
         project.runner
             .addArguments(
                 ":subproject-without-dokka:printJarFileCoords",
                 "--quiet",
                 "--stacktrace",
-                "--no-configuration-cache",
             )
             .forwardOutput()
             .build {

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaPluginFunctionalTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaPluginFunctionalTest.kt
@@ -16,8 +16,8 @@ class DokkaPluginFunctionalTest : FunSpec({
     val testProject = gradleKtsProjectTest("DokkaPluginFunctionalTest") {
 
         gradleProperties {
+            // the built-in Gradle tasks `outgoingVariants` and `resolvableConfigurations` don't support project-iso
             gradle.isolatedProjects = false
-            gradle.configurationCache = false
         }
 
         buildGradleKts = """
@@ -27,7 +27,7 @@ class DokkaPluginFunctionalTest : FunSpec({
             |}
             |
             |val printDeclarableConfigurations by tasks.registering {
-            |  val declarableConfNames = provider { configurations.matching { it.isCanBeDeclared }.names }
+            |  val declarableConfNames = provider { configurations.matching { it.isCanBeDeclared }.names.toList() }
             |  inputs.property("declarableConfNames", declarableConfNames)
             |  doLast {
             |    println("declarableConfigurations:" + declarableConfNames.get())

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaPluginFunctionalTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaPluginFunctionalTest.kt
@@ -15,6 +15,11 @@ import org.jetbrains.dokka.gradle.utils.*
 class DokkaPluginFunctionalTest : FunSpec({
     val testProject = gradleKtsProjectTest("DokkaPluginFunctionalTest") {
 
+        gradleProperties {
+            gradle.isolatedProjects = false
+            gradle.configurationCache = false
+        }
+
         buildGradleKts = """
             |plugins {
             |  id("org.jetbrains.dokka") version "$DOKKA_VERSION"

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaV1TaskDisabledTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaV1TaskDisabledTest.kt
@@ -19,6 +19,7 @@ class DokkaV1TaskDisabledTest : FunSpec({
                 dokka {
                     pluginMode = "V2EnabledWithHelpers"
                 }
+                gradle.isolatedProjects = false
             }
         }
 

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaV1TaskDisabledTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/DokkaV1TaskDisabledTest.kt
@@ -19,6 +19,7 @@ class DokkaV1TaskDisabledTest : FunSpec({
                 dokka {
                     pluginMode = "V2EnabledWithHelpers"
                 }
+                // DGPv1 does not support isolated projects
                 gradle.isolatedProjects = false
             }
         }

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/KotlinDslAccessorsTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/KotlinDslAccessorsTest.kt
@@ -26,7 +26,15 @@ import kotlin.test.assertEquals
 class KotlinDslAccessorsTest : FunSpec({
 
     context("Kotlin DSL generated accessors") {
-        val project = initMultiModuleProject("KotlinDslAccessorsTest")
+        val project = initMultiModuleProject("KotlinDslAccessorsTest") {
+            gradleProperties {
+                // kotlinDslAccessorsReport is not CC compatible
+                // https://github.com/gradle/gradle/issues/28144
+                gradle.configurationCache = false
+                gradle.isolatedProjects = false
+                gradle.buildCache = false
+            }
+        }
 
         /**
          * Verify the current accessors match the dumped accessors.
@@ -99,8 +107,6 @@ class KotlinDslAccessorsTest : FunSpec({
                     ":compileKotlin",
                     "--project-dir", "buildSrc",
                     "--rerun-tasks",
-                    "--no-build-cache",
-                    "--no-configuration-cache",
                 )
                 .build {
                     shouldHaveTaskWithOutcome(":compileKotlin", SUCCESS)

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MigrationMessagesTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MigrationMessagesTest.kt
@@ -24,6 +24,8 @@ class MigrationMessagesTest : FunSpec({
                     pluginMode = null
                     pluginModeNoWarn = null
                 }
+                // must disable project iso, because all projects must be configured to trigger the logged warnings
+                gradle.isolatedProjects = false
             }
         }
 

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/MultiModuleFunctionalTest.kt
@@ -443,7 +443,12 @@ class MultiModuleFunctionalTest : FunSpec({
     }
 
     context("logging") {
-        val project = initMultiModuleProject("logging")
+        val project = initMultiModuleProject("logging") {
+            gradleProperties {
+                // disable project iso, because all projects must be configured to trigger the logged warnings
+                gradle.isolatedProjects = false
+            }
+        }
 
         test("expect no logs when built using --quiet log level") {
             project.runner
@@ -517,6 +522,8 @@ class MultiModuleFunctionalTest : FunSpec({
                     else -> line
                 }
             }
+            // disable project iso, because all projects must be configured to trigger the logged warnings
+            gradleProperties.gradle.isolatedProjects = false
         }
 
         test("expect KotlinAdapter not applied to root project") {

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/PluginFeaturesServiceTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/PluginFeaturesServiceTest.kt
@@ -11,7 +11,12 @@ import org.jetbrains.dokka.gradle.utils.projects.initNoConfigMultiModuleProject
 
 class PluginFeaturesServiceTest : FunSpec({
     context("given multi-module project") {
-        val project = initNoConfigMultiModuleProject()
+        val project = initNoConfigMultiModuleProject {
+            gradleProperties {
+                // disable project-iso because subprojects with DGP must be configured to trigger warnings
+                gradle.isolatedProjects = false
+            }
+        }
 
         context("when PluginMode has invalid value") {
             project.runner

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/SuppressKGPGeneratedFilesFunctionalTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/SuppressKGPGeneratedFilesFunctionalTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.dokka.gradle.internal.DokkaConstants.DOKKA_VERSION
 import org.jetbrains.dokka.gradle.utils.*
+import org.jetbrains.dokka.gradle.utils.projects.defaultKgpTestVersion
 import java.nio.file.Path
 import kotlin.io.path.readText
 
@@ -60,7 +61,7 @@ private fun createProject(
 ): GradleProjectTest = gradleKtsProjectTest("suppress-kgp-generated-files-$suppressGeneratedFiles") {
     buildGradleKts = """
         |plugins {
-        |    kotlin("jvm") version "2.3.0" // KGP 2.3.0 is the first version that contains `generatedKotlin` API
+        |    kotlin("jvm") version "$defaultKgpTestVersion"
         |    id("org.jetbrains.dokka") version "$DOKKA_VERSION"
         |}
         |

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/TryK2MessagesTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/TryK2MessagesTest.kt
@@ -19,7 +19,10 @@ class TryK2MessagesTest : FunSpec({
 
         // Test with a multi-module project to verify that even though there
         // are multiple subprojects with Dokka only one message is logged.
-        val project = initMultiModuleProject("TryK2MessagesTest")
+        val project = initMultiModuleProject("TryK2MessagesTest") {
+            // disable project iso, because all projects must be configured to trigger the logged warnings
+            gradleProperties.gradle.isolatedProjects = false
+        }
 
         val k2Flags = listOf(null, true, false)
         val noWarns = listOf(null, true, false)
@@ -102,7 +105,7 @@ class TryK2MessagesTest : FunSpec({
             logLevel: LogLevel,
         ): String {
             val args = buildList {
-                add(":help")
+                add("help")
                 add("--dry-run")
                 k2Enabled?.let { add("-P$K2_ANALYSIS_ENABLED_FLAG=$it") }
                 if (logLevel != LIFECYCLE) add("--${logLevel.name.lowercase()}")

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
@@ -24,7 +24,9 @@ class LogHtmlPublicationLinkTaskTest : FunSpec({
         val validServerUriParam = `-P`("testServerUri=$validServerUri")
 
         context("and a Kotlin project") {
-            val project = initDokkaProject()
+            val project = initDokkaProject {
+                gradleProperties.gradle.isolatedProjects = false
+            }
 
             context("when generate task is run with correct server URI") {
                 project.runner

--- a/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFunctional/kotlin/tasks/LogHtmlPublicationLinkTaskTest.kt
@@ -12,6 +12,7 @@ import org.gradle.testkit.runner.TaskOutcome.SKIPPED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.jetbrains.dokka.gradle.internal.DokkaConstants
 import org.jetbrains.dokka.gradle.utils.*
+import org.jetbrains.dokka.gradle.utils.projects.defaultKgpTestVersion
 
 class LogHtmlPublicationLinkTaskTest : FunSpec({
 
@@ -24,9 +25,7 @@ class LogHtmlPublicationLinkTaskTest : FunSpec({
         val validServerUriParam = `-P`("testServerUri=$validServerUri")
 
         context("and a Kotlin project") {
-            val project = initDokkaProject {
-                gradleProperties.gradle.isolatedProjects = false
-            }
+            val project = initDokkaProject()
 
             context("when generate task is run with correct server URI") {
                 project.runner
@@ -104,7 +103,7 @@ private fun initDokkaProject(
     return gradleKtsProjectTest("log-html-publication-link-task") {
         buildGradleKts = """
             |plugins {
-            |  kotlin("jvm") version "1.8.22"
+            |  kotlin("jvm") version "$defaultKgpTestVersion"
             |  id("org.jetbrains.dokka") version "${DokkaConstants.DOKKA_VERSION}"
             |}
             |

--- a/examples/gradle-v2/kotlin-multiplatform-example/gradle.properties
+++ b/examples/gradle-v2/kotlin-multiplatform-example/gradle.properties
@@ -9,3 +9,6 @@ org.gradle.parallel=true
 # Otherwise, Dokka will produce 'Error class: unknown class'
 # for CoroutineScope appearing in the generated docs because of absent klibs
 kotlin.native.enableKlibsCrossCompilation=false
+
+# KT-80311 Kotlin JS and Wasm do not support isolated projects
+org.gradle.unsafe.isolated-projects=false


### PR DESCRIPTION
Instead of reading flags from `Project.findProperty()` (which doesn't support project-iso), instead read from `gradle.properties` files. This is only necessary for testing DGP using `ProjectBuilder`, since Dokka currently uses Gradle 8.

Enable project-iso by default #4490. Disable it in projects that require projects are configured.

Bump KGP version in `initMultiModuleProject`/`initNoConfigMultiModuleProject` projects to avoid KT-77988.

Fix #4488
Fix #4490