### PR TITLE
Update Kotlin to 2.3.21

### DIFF
--- a/build-logic/src/main/kotlin/dokkabuild/utils/gradleKotlinCompatibility.kt
+++ b/build-logic/src/main/kotlin/dokkabuild/utils/gradleKotlinCompatibility.kt
@@ -21,7 +21,7 @@ fun Project.configureGradleKotlinCompatibility() {
      * See https://kotlinlang.org/docs/kotlin-evolution-principles.html#evolving-the-binary-format
      */
     val analysisK2Projects = listOf("analysis-kotlin-symbols", "runner-maven-plugin")
-    if (!dokkaBuild.enforceGradleKotlinCompatibility.get() ||  project.name in analysisK2Projects) return
+    if (!dokkaBuild.enforceGradleKotlinCompatibility.get() || project.name in analysisK2Projects) return
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalBuildToolsApi::class)
     extensions.configure<KotlinJvmProjectExtension>("kotlin") {
@@ -37,6 +37,17 @@ fun Project.configureGradleKotlinCompatibility() {
                 // we need this flag to be able to use newer Analysis API versions
                 "-Xskip-metadata-version-check"
             )
+        }
+
+        // see https://youtrack.jetbrains.com/issue/KT-86158
+        configurations.named { it.startsWith("kotlinCompilerPluginClasspath") }.configureEach {
+            resolutionStrategy {
+                eachDependency {
+                    if (requested.group == "org.jetbrains.kotlin") {
+                        useVersion(btaCompilerVersion.get())
+                    }
+                }
+            }
         }
     }
 }

--- a/docs/v.list
+++ b/docs/v.list
@@ -7,6 +7,6 @@
          value="2.2.0"
          type="string"/>
     <var name="kotlinVersion"
-         value="2.3.0"
+         value="2.3.21"
          type="string"/>
 </vars>

--- a/dokka-integration-tests/gradle/projects/README.md
+++ b/dokka-integration-tests/gradle/projects/README.md
@@ -3,7 +3,7 @@
 Projects used to run integration tests could be opened in or build independently by following these steps:
 
 1. open `gradle.properties` file of a specific project and change commented variables:
-    1. `dokka_it_kotlin_version` to required version of Kotlin Gradle Plugin, e.g 2.3.0
+    1. `dokka_it_kotlin_version` to required version of Kotlin Gradle Plugin, e.g 2.3.21
     2. `dokka_it_dokka_version` to required version to Dokka Gradle plugin, e.g 2.2.0
     3. replace all other commented properties if needed, like `dokka_it_android_gradle_plugin_version`
 2. open `settings.gradle.kts` and replace `apply(from = "template.settings.gradle.kts")` with

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -14,7 +14,7 @@ open class AllSupportedTestedVersionsArgumentsProvider : TestedVersionsArguments
 
 object TestedVersions {
 
-    val LATEST = BuildVersions("8.14.3", "2.3.0")
+    val LATEST = BuildVersions("8.14.3", "2.3.21")
 
     /**
      * All supported Gradle/Kotlin versions, including [LATEST]
@@ -38,7 +38,7 @@ object TestedVersions {
     val ANDROID =
         BuildVersions.permutations(
             gradleVersions = listOf("8.4"),
-            kotlinVersions = listOf("2.3.0", "2.2.21", "2.1.21", "2.0.21"),
+            kotlinVersions = listOf("2.3.21", "2.2.21", "2.1.21", "2.0.21"),
             androidGradlePluginVersions = listOf("8.3.0")
         ) + BuildVersions.permutations(
             gradleVersions = listOf("7.6.3"),
@@ -52,7 +52,7 @@ object TestedVersions {
         "2.0.21" to "18.3.1-pre.758",
         "2.1.21" to "2025.6.2-19.1.0",
         "2.2.21" to "2025.10.3-19.2.0",
-        "2.3.0" to "2025.12.7-19.2.3",
+        "2.3.21" to "2026.5.3-19.2.6",
     )
 }
 

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
@@ -47,7 +47,7 @@ fun interface TestedVersionsSource<T : TestedVersions> {
             "2.0.21",
             "2.1.21",
             "2.2.21",
-            "2.3.0",
+            "2.3.21",
         )
 
         /**

--- a/dokka-integration-tests/gradle/src/test/kotlin/junit/TestedVersionsSourceTest.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/junit/TestedVersionsSourceTest.kt
@@ -27,8 +27,8 @@ import org.junit.jupiter.params.provider.EnumSource
  * For example, after adding Kotlin 2.4.0 to `allKgpVersions in [TestedVersionsSource.Default],
  * `test default versions` test will fail showing:
  * ```
- * expected: <"... kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.0 ...">
- * but was:  <"... kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.0, 2.4.0 ...">
+ * expected: <"... kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.21 ...">
+ * but was:  <"... kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.21, 2.4.0 ...">
  * ```
  * Verify that the values are expected and replace the expected string in the test with an actual output.
  */
@@ -40,7 +40,7 @@ class TestedVersionsSourceTest {
 
         actual shouldBe """
             gradle: 7.6.6, 8.14.4, 9.4.0
-            kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.0
+            kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.21
         """.trimIndent()
     }
 
@@ -57,14 +57,14 @@ class TestedVersionsSourceTest {
                 """
                 agp: 9.0.0
                 gradle: 9.4.0
-                kgp: 2.1.21, 2.2.21, 2.3.0
+                kgp: 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
             Supported ->
                 """
                 agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2, 9.0.0
                 gradle: 7.6.6, 8.14.4, 9.4.0
-                kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.0
+                kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
             Incompatible ->
@@ -92,7 +92,7 @@ class TestedVersionsSourceTest {
                 agp: 9.0.0
                 composeGradlePlugin: 1.7.0
                 gradle: 9.4.0
-                kgp: 2.1.21, 2.2.21, 2.3.0
+                kgp: 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
             Supported ->
@@ -100,7 +100,7 @@ class TestedVersionsSourceTest {
                 agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2, 9.0.0
                 composeGradlePlugin: 1.7.0
                 gradle: 7.6.6, 8.14.4, 9.4.0
-                kgp: 2.0.21, 2.1.21, 2.2.21, 2.3.0
+                kgp: 2.0.21, 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
             Incompatible ->

--- a/dokka-runners/dokka-gradle-plugin/gradle.properties
+++ b/dokka-runners/dokka-gradle-plugin/gradle.properties
@@ -9,7 +9,6 @@ version=2.3.0-SNAPSHOT
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.enforceGradleKotlinCompatibility=true
-kotlin.compiler.runViaBuildToolsApi=true
 
 # Gradle settings
 org.gradle.jvmargs=-Dfile.encoding=UTF-8

--- a/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/versions.kt
+++ b/dokka-runners/dokka-gradle-plugin/src/testFixtures/kotlin/projects/versions.kt
@@ -14,4 +14,4 @@ package org.jetbrains.dokka.gradle.utils.projects
 // Must use KGP >= 2.3.0:
 // - to avoid KT-77988
 // - to test `generatedKotlin` API
-const val defaultKgpTestVersion = "2.3.0"
+const val defaultKgpTestVersion = "2.3.21"

--- a/dokka-runners/runner-cli/gradle.properties
+++ b/dokka-runners/runner-cli/gradle.properties
@@ -9,4 +9,3 @@ version=2.3.0-SNAPSHOT
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.enforceGradleKotlinCompatibility=false
-kotlin.compiler.runViaBuildToolsApi=true

--- a/dokka-runners/runner-maven-plugin/gradle.properties
+++ b/dokka-runners/runner-maven-plugin/gradle.properties
@@ -7,4 +7,3 @@ version=2.3.0-SNAPSHOT
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.enforceGradleKotlinCompatibility=true
-kotlin.compiler.runViaBuildToolsApi=true

--- a/examples/gradle-v2/basic-gradle-example/build.gradle.kts
+++ b/examples/gradle-v2/basic-gradle-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
 }
 

--- a/examples/gradle-v2/custom-dokka-plugin-example/build.gradle.kts
+++ b/examples/gradle-v2/custom-dokka-plugin-example/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     base
 
-    kotlin("jvm") version "2.3.0" apply false
-    kotlin("plugin.serialization") version "2.3.0" apply false
+    kotlin("jvm") version "2.3.21" apply false
+    kotlin("plugin.serialization") version "2.3.21" apply false
     id("org.jetbrains.dokka") version "2.2.0" apply false
 }

--- a/examples/gradle-v2/custom-styling-example/build.gradle.kts
+++ b/examples/gradle-v2/custom-styling-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
 }
 

--- a/examples/gradle-v2/javadoc-example/build.gradle.kts
+++ b/examples/gradle-v2/javadoc-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka-javadoc") version "2.2.0"
 }
 

--- a/examples/gradle-v2/kotlin-as-java-example/build.gradle.kts
+++ b/examples/gradle-v2/kotlin-as-java-example/build.gradle.kts
@@ -3,7 +3,7 @@
  */
 
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
 }
 

--- a/examples/gradle-v2/kotlin-multiplatform-example/build.gradle.kts
+++ b/examples/gradle-v2/kotlin-multiplatform-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("multiplatform") version "2.3.0"
+    kotlin("multiplatform") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
 }
 

--- a/examples/gradle-v2/library-publishing-example/build.gradle.kts
+++ b/examples/gradle-v2/library-publishing-example/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
     id("org.jetbrains.dokka-javadoc") version "2.2.0"
     `maven-publish`

--- a/examples/gradle/dokka-customFormat-example/build.gradle.kts
+++ b/examples/gradle/dokka-customFormat-example/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
 
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
 }
 

--- a/examples/gradle/dokka-gradle-example/build.gradle.kts
+++ b/examples/gradle/dokka-gradle-example/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import java.net.URL
 
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
 }
 

--- a/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
+++ b/examples/gradle/dokka-kotlinAsJava-example/build.gradle.kts
@@ -3,7 +3,7 @@
  */
 
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
 }
 

--- a/examples/gradle/dokka-library-publishing-example/build.gradle.kts
+++ b/examples/gradle/dokka-library-publishing-example/build.gradle.kts
@@ -3,7 +3,7 @@
  */
 
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
     `java-library`
     `maven-publish`

--- a/examples/gradle/dokka-multiplatform-example/build.gradle.kts
+++ b/examples/gradle/dokka-multiplatform-example/build.gradle.kts
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.dokka.Platform
 
 plugins {
-    kotlin("multiplatform") version "2.3.0"
+    kotlin("multiplatform") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
 }
 

--- a/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
+++ b/examples/gradle/dokka-versioning-multimodule-example/build.gradle.kts
@@ -3,7 +3,7 @@
  */
 
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0" apply false
 }
 

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>kotlin-maven-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <kotlin.version>2.3.0</kotlin.version>
+        <kotlin.version>2.3.21</kotlin.version>
         <dokka.version>2.2.0</dokka.version>
     </properties>
 

--- a/examples/plugin/hide-internal-api/build.gradle.kts
+++ b/examples/plugin/hide-internal-api/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URI
 
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("org.jetbrains.dokka") version "2.2.0"
     `maven-publish`
     signing

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@ version=2.3.0-SNAPSHOT
 org.jetbrains.dokka.javaToolchain.mainCompiler=8
 org.jetbrains.dokka.javaToolchain.testLauncher=8
 org.jetbrains.dokka.enforceGradleKotlinCompatibility=true
-kotlin.compiler.runViaBuildToolsApi=true
 
 # Code style
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@
 bta-kotlin-compiler = "2.0.21"
 bta-kotlin-language = "1.4"
 
-gradlePlugin-kotlin = "2.3.0"
+gradlePlugin-kotlin = "2.3.21"
 # See: https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
 gradlePlugin-android = "7.3.1"
 


### PR DESCRIPTION
- Updated KGP version used to build Dokka.
  - BTA is enabled by default for JVM compilations, so `kotlin.compiler.runViaBuildToolsApi=true` could be dropped.
  - In KGP 2.4.0, usage of this property will emit a warning.
- Updated Kotlin version used for **tests** (both IT and Gradle functional tests).
- Added workaround for https://youtrack.jetbrains.com/issue/KT-86158.
  - Strictly speaking, it's not needed currently, but it will be required after the update to KGP 2.4.0.