### PR TITLE
Update Gradle to 8.14.5 in the build and in tests

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -14,7 +14,7 @@ open class AllSupportedTestedVersionsArgumentsProvider : TestedVersionsArguments
 
 object TestedVersions {
 
-    val LATEST = BuildVersions("8.14.3", "2.3.21")
+    val LATEST = BuildVersions("8.14.5", "2.3.21")
 
     /**
      * All supported Gradle/Kotlin versions, including [LATEST]

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
@@ -57,8 +57,8 @@ fun interface TestedVersionsSource<T : TestedVersions> {
          */
         private val allGradleVersions: List<String> = listOf(
             "7.6.6",
-            "8.14.4",
-            "9.4.0",
+            "8.14.5",
+            "9.5.1",
         )
 
         private val allVersions: Sequence<TestedVersions.Default> =

--- a/dokka-integration-tests/gradle/src/test/kotlin/junit/TestedVersionsSourceTest.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/junit/TestedVersionsSourceTest.kt
@@ -39,7 +39,7 @@ class TestedVersionsSourceTest {
         val actual = TestedVersionsSource.Default.get().joinAllToString()
 
         actual shouldBe """
-            gradle: 7.6.6, 8.14.4, 9.4.0
+            gradle: 7.6.6, 8.14.5, 9.5.1
             kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.21
         """.trimIndent()
     }
@@ -56,21 +56,21 @@ class TestedVersionsSourceTest {
             Required ->
                 """
                 agp: 9.0.0
-                gradle: 9.4.0
+                gradle: 9.5.1
                 kgp: 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
             Supported ->
                 """
                 agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2, 9.0.0
-                gradle: 7.6.6, 8.14.4, 9.4.0
+                gradle: 7.6.6, 8.14.5, 9.5.1
                 kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
             Incompatible ->
                 """
                 agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2
-                gradle: 7.6.6, 8.14.4
+                gradle: 7.6.6, 8.14.5
                 kgp: 1.9.25, 2.0.21
                 """.trimIndent()
         }
@@ -91,7 +91,7 @@ class TestedVersionsSourceTest {
                 """
                 agp: 9.0.0
                 composeGradlePlugin: 1.7.0
-                gradle: 9.4.0
+                gradle: 9.5.1
                 kgp: 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
@@ -99,7 +99,7 @@ class TestedVersionsSourceTest {
                 """
                 agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2, 9.0.0
                 composeGradlePlugin: 1.7.0
-                gradle: 7.6.6, 8.14.4, 9.4.0
+                gradle: 7.6.6, 8.14.5, 9.5.1
                 kgp: 2.0.21, 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
@@ -107,7 +107,7 @@ class TestedVersionsSourceTest {
                 """
                 agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2
                 composeGradlePlugin: 1.7.0
-                gradle: 7.6.6, 8.14.4
+                gradle: 7.6.6, 8.14.5
                 kgp: 2.0.21
                 """.trimIndent()
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7197a12f450794931532469d4ff21a59ea2c1cd59a3ec3f89c035c3c420a6999
-distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
+distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Based on #4505

KGP 2.4.0 will emit a warning about the old Gradle version used