### PR TITLE
Update tested AGP versions

### DIFF
--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/TestedVersions.kt
@@ -37,13 +37,9 @@ object TestedVersions {
      */
     val ANDROID =
         BuildVersions.permutations(
-            gradleVersions = listOf("8.4"),
+            gradleVersions = listOf("8.7"),
             kotlinVersions = listOf("2.3.21", "2.2.21", "2.1.21", "2.0.21"),
-            androidGradlePluginVersions = listOf("8.3.0")
-        ) + BuildVersions.permutations(
-            gradleVersions = listOf("7.6.3"),
-            kotlinVersions = listOf("1.9.25"),
-            androidGradlePluginVersions = listOf("7.4.2")
+            androidGradlePluginVersions = listOf("8.5.2")
         )
 
     // https://mvnrepository.com/artifact/org.jetbrains.kotlin-wrappers/kotlin-react

--- a/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
+++ b/dokka-integration-tests/gradle/src/main/kotlin/org/jetbrains/dokka/it/gradle/junit/TestedVersionsSource.kt
@@ -102,17 +102,17 @@ fun interface TestedVersionsSource<T : TestedVersions> {
         /**
          * All possible Android Gradle Plugin versions that could be tested.
          *
-         * We test the latest v7, v8, and v9 AGP versions.
+         * We test the latest v8, and v9 AGP versions, as well as other KGP dependent versions.
+         * See https://kotlinlang.org/docs/multiplatform/multiplatform-compatibility-guide.html#version-compatibility
          *
          * Note the AGP major version indicates the required major version of Gradle.
-         * So, AGP 7.* supports Gradle 7, but will throw an error if used with Gradle 8.
+         * So, AGP 8.* supports Gradle 8, but will throw an error if used with Gradle 9.
          */
         private val allAgpVersions: List<SemVer> = listOf(
-            "7.4.2",
-            "8.11.2",
-            "8.12.3",
-            "8.13.2",
-            "9.0.0",
+            "8.5.2", // minimal KGP supported version for Kotlin 2.4.0
+            "8.13.2", // latest AGP 8 version
+            "9.0.0", // latest Kotlin 2.3.21 supported version
+            "9.2.1", // latest AGP9 version
         ).map { SemVer(it) }
 
         private val matchedAgpVersions: List<SemVer> =
@@ -151,6 +151,7 @@ fun interface TestedVersionsSource<T : TestedVersions> {
             // AGP/Gradle compatibility definitions:
             // https://developer.android.com/build/releases/gradle-plugin?buildsystem=ndk-build#updating-gradle
             return when (agp.majorAndMinorVersions) {
+                "9.2" -> gradle.major >= 9
                 "9.0" -> gradle.major >= 9
                 "8.13" -> gradle in "8.13.0".."9.0.0"
                 "8.12" -> gradle in "8.13.0".."9.0.0"

--- a/dokka-integration-tests/gradle/src/test/kotlin/junit/TestedVersionsSourceTest.kt
+++ b/dokka-integration-tests/gradle/src/test/kotlin/junit/TestedVersionsSourceTest.kt
@@ -55,22 +55,22 @@ class TestedVersionsSourceTest {
         val expected = when (kotlinBuiltIn) {
             Required ->
                 """
-                agp: 9.0.0
+                agp: 9.0.0, 9.2.1
                 gradle: 9.5.1
                 kgp: 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
             Supported ->
                 """
-                agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2, 9.0.0
-                gradle: 7.6.6, 8.14.5, 9.5.1
+                agp: 8.5.2, 8.13.2, 9.0.0, 9.2.1
+                gradle: 8.14.5, 9.5.1
                 kgp: 1.9.25, 2.0.21, 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
             Incompatible ->
                 """
-                agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2
-                gradle: 7.6.6, 8.14.5
+                agp: 8.5.2, 8.13.2
+                gradle: 8.14.5
                 kgp: 1.9.25, 2.0.21
                 """.trimIndent()
         }
@@ -89,7 +89,7 @@ class TestedVersionsSourceTest {
         val expected = when (kotlinBuiltIn) {
             Required ->
                 """
-                agp: 9.0.0
+                agp: 9.0.0, 9.2.1
                 composeGradlePlugin: 1.7.0
                 gradle: 9.5.1
                 kgp: 2.1.21, 2.2.21, 2.3.21
@@ -97,17 +97,17 @@ class TestedVersionsSourceTest {
 
             Supported ->
                 """
-                agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2, 9.0.0
+                agp: 8.5.2, 8.13.2, 9.0.0, 9.2.1
                 composeGradlePlugin: 1.7.0
-                gradle: 7.6.6, 8.14.5, 9.5.1
+                gradle: 8.14.5, 9.5.1
                 kgp: 2.0.21, 2.1.21, 2.2.21, 2.3.21
                 """.trimIndent()
 
             Incompatible ->
                 """
-                agp: 7.4.2, 8.11.2, 8.12.3, 8.13.2
+                agp: 8.5.2, 8.13.2
                 composeGradlePlugin: 1.7.0
-                gradle: 7.6.6, 8.14.5
+                gradle: 8.14.5
                 kgp: 2.0.21
                 """.trimIndent()
         }


### PR DESCRIPTION
Based on #4506

Fixes #4456

KGP 2.4.0 will make 8.5.2 the minimal supported AGP version

Note: I haven't touched the AGP [version](https://github.com/Kotlin/dokka/blob/42fd681a28e11476785a6931e37835a54f05af22/gradle/libs.versions.toml#L12) against which we compile DGP, because updating it to AGP 8.* would require us to compile DGP with JDK 11 (as AGP requires it), which would complicate the current setup. As for now, we don't really need access to newer APIs, so it's fine.

Q: Do we need to add additional checks at runtime in DGP regarding supported versions?
A: I don't think that's strictly necessary at this moment.