### PR TITLE
Removes workardound for #1306

### DIFF
--- a/dokka-integration-tests/gradle/src/testTemplateProjectAndroid/kotlin/Android0GradleIntegrationTest.kt
+++ b/dokka-integration-tests/gradle/src/testTemplateProjectAndroid/kotlin/Android0GradleIntegrationTest.kt
@@ -57,7 +57,7 @@ class Android0GradleIntegrationTest : AbstractGradleIntegrationTest() {
 
         htmlOutputDir.allHtmlFiles().forEach { file ->
             assertContainsNoErrorClass(file)
-            assertNoUnresolvedLinks(file, knownUnresolvedDRIs)
+            assertNoUnresolvedLinks(file)
             assertNoHrefToMissingLocalFileOrDirectory(file)
             assertNoEmptyLinks(file)
             assertNoEmptySpans(file)
@@ -82,12 +82,4 @@ class Android0GradleIntegrationTest : AbstractGradleIntegrationTest() {
             assertNoHrefToMissingLocalFileOrDirectory(file)
         }
     }
-
-    // TODO: remove this list when https://github.com/Kotlin/dokka/issues/1306 is closed
-    private val knownUnresolvedDRIs = setOf(
-        "it.android/IntegrationTestActivity/findViewById/#kotlin.Int/PointingToGenericParameters(0)/",
-        "it.android/IntegrationTestActivity/getExtraData/#java.lang.Class[TypeParam(bounds=[androidx.core.app.ComponentActivity.ExtraData])]/PointingToGenericParameters(0)/",
-        "it.android/IntegrationTestActivity/getSystemService/#java.lang.Class[TypeParam(bounds=[kotlin.Any])]/PointingToGenericParameters(0)/",
-        "it.android/IntegrationTestActivity/requireViewById/#kotlin.Int/PointingToGenericParameters(0)/"
-    )
 }

--- a/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/AbstractIntegrationTest.kt
+++ b/dokka-integration-tests/utilities/src/main/kotlin/org/jetbrains/dokka/it/AbstractIntegrationTest.kt
@@ -45,13 +45,13 @@ abstract class AbstractIntegrationTest {
         )
     }
 
-    protected fun assertNoUnresolvedLinks(file: File, exceptions: Set<String> = emptySet()) {
+    protected fun assertNoUnresolvedLinks(file: File) {
         val fileText = file.readText()
         val regex = Regex("""data-unresolved-link="\[(.+?(?=]"))""")
         val match = regex.findAll(fileText).map { it.groups[1]!!.value }
 
         assertTrue(
-            match.filterNot { it in exceptions }.toList().isEmpty(),
+            match.toList().isEmpty(),
             "Unexpected unresolved link in ${file.path}\n" + fileText
         )
     }


### PR DESCRIPTION
I've checked the test locally, and it doesn't fail anymore, so it looks like it's something very-very old.

I've also checked the HTML output here, and in this case, generic parameters just link to the same page...
It looks like #3054, but here it's about generic parameters.

After that, I've checked the codebase, and overall it looks like Dokka doesn't really support **rendering** links to any kind of **parameters** via DRI, or am I missing something?
We do check DRI targets when [creating sections](https://github.com/Kotlin/dokka/blob/c821d5bf6ca4ba36f7050987f640c81f1a30e533/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DescriptionSections.kt#L119-L124), but those are coming from `Param` tag only.
I don't say it's a bug, just an interesting observation.