### PR TITLE
Add support for KEEP-0449: the companion block and the companion modifier on extensions

### DIFF
--- a/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/index.html
+++ b/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/index.html
@@ -119,12 +119,12 @@
       </div>
       <div data-togglable="FUNCTION">
         <h2 class="tableheader">Companion functions</h2>
-        <div class="table"><a data-name="-1628211551%2FFunctions%2F1104572647" anchor-label="main" id="-1628211551%2FFunctions%2F1104572647" data-filterable-set=":my-java-application/javaMain"></a>
+        <div class="table"><a data-name="-1055449593%2FFunctions%2F1104572647" anchor-label="main" id="-1055449593%2FFunctions%2F1104572647" data-filterable-set=":my-java-application/javaMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":my-java-application/javaMain" data-filterable-set=":my-java-application/javaMain">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
                   <div><a href="main.html"><span><span>main</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1628211551%2FFunctions%2F1104572647"></span>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1055449593%2FFunctions%2F1104572647"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>

--- a/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/index.html
+++ b/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/index.html
@@ -117,7 +117,7 @@
           </div>
         </div>
       </div>
-      <div data-togglable="PROPERTY">
+      <div data-togglable="FUNCTION">
         <h2 class="tableheader">Companion functions</h2>
         <div class="table"><a data-name="-1628211551%2FFunctions%2F1104572647" anchor-label="main" id="-1628211551%2FFunctions%2F1104572647" data-filterable-set=":my-java-application/javaMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":my-java-application/javaMain" data-filterable-set=":my-java-application/javaMain">

--- a/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/index.html
+++ b/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/index.html
@@ -117,14 +117,14 @@
           </div>
         </div>
       </div>
-      <div data-togglable="FUNCTION">
-        <h2 class="tableheader">Functions</h2>
-        <div class="table"><a data-name="-509975004%2FFunctions%2F1104572647" anchor-label="main" id="-509975004%2FFunctions%2F1104572647" data-filterable-set=":my-java-application/javaMain"></a>
+      <div data-togglable="PROPERTY">
+        <h2 class="tableheader">Companion functions</h2>
+        <div class="table"><a data-name="-1628211551%2FFunctions%2F1104572647" anchor-label="main" id="-1628211551%2FFunctions%2F1104572647" data-filterable-set=":my-java-application/javaMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":my-java-application/javaMain" data-filterable-set=":my-java-application/javaMain">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
                   <div><a href="main.html"><span><span>main</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-509975004%2FFunctions%2F1104572647"></span>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1628211551%2FFunctions%2F1104572647"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>

--- a/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/main.html
+++ b/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/main.html
@@ -89,7 +89,7 @@
         </nav>
         <div id="resizer" class="resizer" data-item-type="BAR"></div>
         <div id="main" data-item-type="SECTION" role="main">
-<div class="main-content" data-page-type="member" id="content" pageids="my-java-application::demo/MyJavaApplication/main/#java.lang.String[]/PointingToDeclaration//1104572647">
+<div class="main-content" data-page-type="member" id="content" pageids="my-java-application::demo/MyJavaApplication/main/#java.lang.String[]/static/PointingToDeclaration//1104572647">
   <div class="breadcrumbs"><a href="../../index.html">my-java-application</a><span class="delimiter">/</span><a href="../index.html">demo</a><span class="delimiter">/</span><a href="index.html">MyJavaApplication</a><span class="delimiter">/</span><span class="current">main</span></div>
   <div class="cover ">
     <h1 class="cover"><span><span>main</span></span></h1>

--- a/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/main.html
+++ b/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-application/demo/-my-java-application/main.html
@@ -89,7 +89,7 @@
         </nav>
         <div id="resizer" class="resizer" data-item-type="BAR"></div>
         <div id="main" data-item-type="SECTION" role="main">
-<div class="main-content" data-page-type="member" id="content" pageids="my-java-application::demo/MyJavaApplication/main/#java.lang.String[]/static/PointingToDeclaration//1104572647">
+<div class="main-content" data-page-type="member" id="content" pageids="my-java-application::demo/MyJavaApplication/main/#java.lang.String[]/companion/PointingToDeclaration//1104572647">
   <div class="breadcrumbs"><a href="../../index.html">my-java-application</a><span class="delimiter">/</span><a href="../index.html">demo</a><span class="delimiter">/</span><a href="index.html">MyJavaApplication</a><span class="delimiter">/</span><span class="current">main</span></div>
   <div class="cover ">
     <h1 class="cover"><span><span>main</span></span></h1>

--- a/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-library/demo/-my-java-library-class/index.html
+++ b/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-library/demo/-my-java-library-class/index.html
@@ -118,18 +118,18 @@
         </div>
       </div>
       <div data-togglable="PROPERTY">
-        <h2 class="tableheader">Properties</h2>
-        <div class="table"><a data-name="891316083%2FProperties%2F-1288592932" anchor-label="WELCOME" id="891316083%2FProperties%2F-1288592932" data-filterable-set=":my-java-library/javaMain"></a>
+        <h2 class="tableheader">Companion properties</h2>
+        <div class="table"><a data-name="1482108530%2FProperties%2F-1288592932" anchor-label="WELCOME" id="1482108530%2FProperties%2F-1288592932" data-filterable-set=":my-java-library/javaMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":my-java-library/javaMain" data-filterable-set=":my-java-library/javaMain">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
-                  <div><a href="index.html#891316083%2FProperties%2F-1288592932"><span><span>WELCOME</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="891316083%2FProperties%2F-1288592932"></span>
+                  <div><a href="index.html#1482108530%2FProperties%2F-1288592932"><span><span>WELCOME</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1482108530%2FProperties%2F-1288592932"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>
                 <div class="title">
-                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":my-java-library/javaMain"><div class="symbol monospace block"><span class="token keyword">public </span><span class="token keyword">final </span><span class="token keyword">static </span><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html">String</a>&nbsp;<a href="index.html#891316083%2FProperties%2F-1288592932">WELCOME</a></div></div></div>
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":my-java-library/javaMain"><div class="symbol monospace block"><span class="token keyword">public </span><span class="token keyword">final </span><span class="token keyword">static </span><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html">String</a>&nbsp;<a href="index.html#1482108530%2FProperties%2F-1288592932">WELCOME</a></div></div></div>
                 </div>
               </div>
             </div>

--- a/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-library/demo/-my-java-library-class/index.html
+++ b/dokka-integration-tests/gradle/src/testExampleProjects/expectedData/exampleProjects/java-example/html/my-java-library/demo/-my-java-library-class/index.html
@@ -119,17 +119,17 @@
       </div>
       <div data-togglable="PROPERTY">
         <h2 class="tableheader">Companion properties</h2>
-        <div class="table"><a data-name="1482108530%2FProperties%2F-1288592932" anchor-label="WELCOME" id="1482108530%2FProperties%2F-1288592932" data-filterable-set=":my-java-library/javaMain"></a>
+        <div class="table"><a data-name="-1134360426%2FProperties%2F-1288592932" anchor-label="WELCOME" id="-1134360426%2FProperties%2F-1288592932" data-filterable-set=":my-java-library/javaMain"></a>
           <div class="table-row table-row_content" data-filterable-current=":my-java-library/javaMain" data-filterable-set=":my-java-library/javaMain">
             <div class="main-subrow keyValue ">
               <div class=""><span class="inline-flex">
-                  <div><a href="index.html#1482108530%2FProperties%2F-1288592932"><span><span>WELCOME</span></span></a></div>
-<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="1482108530%2FProperties%2F-1288592932"></span>
+                  <div><a href="index.html#-1134360426%2FProperties%2F-1288592932"><span><span>WELCOME</span></span></a></div>
+<span class="anchor-wrapper"><span class="anchor-icon" pointing-to="-1134360426%2FProperties%2F-1288592932"></span>
                     <div class="copy-popup-wrapper "><span class="copy-popup-icon"></span><span>Link copied to clipboard</span></div>
                   </span></span></div>
               <div>
                 <div class="title">
-                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":my-java-library/javaMain"><div class="symbol monospace block"><span class="token keyword">public </span><span class="token keyword">final </span><span class="token keyword">static </span><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html">String</a>&nbsp;<a href="index.html#1482108530%2FProperties%2F-1288592932">WELCOME</a></div></div></div>
+                  <div class="platform-hinted " data-platform-hinted="data-platform-hinted"><div class="content sourceset-dependent-content" data-active="" data-togglable=":my-java-library/javaMain"><div class="symbol monospace block"><span class="token keyword">public </span><span class="token keyword">final </span><span class="token keyword">static </span><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html">String</a>&nbsp;<a href="index.html#-1134360426%2FProperties%2F-1288592932">WELCOME</a></div></div></div>
                 </div>
               </div>
             </div>

--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
@@ -466,7 +466,7 @@ internal class DokkaPsiParser(
                     ObviousMember.takeIf { psi.isObvious(inheritedFrom) },
                     helper.getCheckedExceptionDRIs(psi).takeIf { it.isNotEmpty() }
                         ?.let { CheckedExceptions(it.toSourceSetDependent()) },
-                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { isCompanionBlock },
+                    @OptIn(ExperimentalDokkaApi::class) IsCompanion.takeIf { isCompanionBlock },
                 )
             }
         )
@@ -642,7 +642,7 @@ internal class DokkaPsiParser(
                     annotations.toSourceSetDependent().toAnnotations(),
                     helper.getConstantExpression(psi)?.let { DefaultValue(it.toSourceSetDependent()) },
                     takeIf { isVar }?.let { IsVar },
-                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { psi.hasModifier(JvmModifier.STATIC) },
+                    @OptIn(ExperimentalDokkaApi::class) IsCompanion.takeIf { psi.hasModifier(JvmModifier.STATIC) },
                 )
             }
         )

--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
@@ -421,10 +421,9 @@ internal class DokkaPsiParser(
         parentDRI: DRI? = null,
     ): DFunction {
         val isCompanionBlock = !isConstructor && psi.hasModifier(JvmModifier.STATIC)
-        val baseDri = parentDRI?.let { dri ->
+        val dri = parentDRI?.let { dri ->
             DRI.from(psi).copy(packageName = dri.packageName, classNames = dri.classNames)
         } ?: DRI.from(psi)
-        val dri = baseDri.markStaticIfNeeded(isCompanionBlock)
         val docs = psi.getDocumentation()
         return DFunction(
             dri = dri,
@@ -472,15 +471,6 @@ internal class DokkaPsiParser(
             }
         )
     }
-
-    /**
-     * Marks the callable part of a [DRI] as static so static Java members (and any other
-     * companion-block scope declarations) can be distinguished from instance ones with the
-     * same name on the same classlike.
-     */
-    private fun DRI.markStaticIfNeeded(isCompanionBlock: Boolean): DRI =
-        if (!isCompanionBlock) this
-        else copy(callable = callable?.copy(isCompanion = true))
 
     private fun PsiNamedElement.parseSources(): SourceSetDependent<DocumentableSource> {
         return when {
@@ -617,8 +607,7 @@ internal class DokkaPsiParser(
         setter: DFunction?,
         inheritedFrom: DRI? = null
     ): DProperty {
-        val isCompanionBlock = psi.hasModifier(JvmModifier.STATIC)
-        val dri = DRI.from(psi).markStaticIfNeeded(isCompanionBlock)
+        val dri = DRI.from(psi)
 
         // non-final java field without accessors should be a var
         // setter should be not null when inheriting kotlin vars
@@ -653,7 +642,7 @@ internal class DokkaPsiParser(
                     annotations.toSourceSetDependent().toAnnotations(),
                     helper.getConstantExpression(psi)?.let { DefaultValue(it.toSourceSetDependent()) },
                     takeIf { isVar }?.let { IsVar },
-                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { isCompanionBlock },
+                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { psi.hasModifier(JvmModifier.STATIC) },
                 )
             }
         )

--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/parsers/DokkaPsiParser.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.*
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.ExperimentalDokkaApi
 import org.jetbrains.dokka.analysis.java.BreakingAbstractionKotlinLightMethodChecker
 import org.jetbrains.dokka.analysis.java.SyntheticElementDocumentationProvider
 import org.jetbrains.dokka.analysis.java.getVisibility
@@ -419,9 +420,11 @@ internal class DokkaPsiParser(
         inheritedFrom: DRI? = null,
         parentDRI: DRI? = null,
     ): DFunction {
-        val dri = parentDRI?.let { dri ->
+        val isCompanionBlock = !isConstructor && psi.hasModifier(JvmModifier.STATIC)
+        val baseDri = parentDRI?.let { dri ->
             DRI.from(psi).copy(packageName = dri.packageName, classNames = dri.classNames)
         } ?: DRI.from(psi)
+        val dri = baseDri.markStaticIfNeeded(isCompanionBlock)
         val docs = psi.getDocumentation()
         return DFunction(
             dri = dri,
@@ -463,11 +466,21 @@ internal class DokkaPsiParser(
                         .toAnnotations(),
                     ObviousMember.takeIf { psi.isObvious(inheritedFrom) },
                     helper.getCheckedExceptionDRIs(psi).takeIf { it.isNotEmpty() }
-                        ?.let { CheckedExceptions(it.toSourceSetDependent()) }
+                        ?.let { CheckedExceptions(it.toSourceSetDependent()) },
+                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { isCompanionBlock },
                 )
             }
         )
     }
+
+    /**
+     * Marks the callable part of a [DRI] as static so static Java members (and any other
+     * companion-block scope declarations) can be distinguished from instance ones with the
+     * same name on the same classlike.
+     */
+    private fun DRI.markStaticIfNeeded(isCompanionBlock: Boolean): DRI =
+        if (!isCompanionBlock) this
+        else copy(callable = callable?.copy(isCompanion = true))
 
     private fun PsiNamedElement.parseSources(): SourceSetDependent<DocumentableSource> {
         return when {
@@ -604,7 +617,8 @@ internal class DokkaPsiParser(
         setter: DFunction?,
         inheritedFrom: DRI? = null
     ): DProperty {
-        val dri = DRI.from(psi)
+        val isCompanionBlock = psi.hasModifier(JvmModifier.STATIC)
+        val dri = DRI.from(psi).markStaticIfNeeded(isCompanionBlock)
 
         // non-final java field without accessors should be a var
         // setter should be not null when inheriting kotlin vars
@@ -638,7 +652,8 @@ internal class DokkaPsiParser(
                     it.toSourceSetDependent().toAdditionalModifiers(),
                     annotations.toSourceSetDependent().toAnnotations(),
                     helper.getConstantExpression(psi)?.let { DefaultValue(it.toSourceSetDependent()) },
-                    takeIf { isVar }?.let { IsVar }
+                    takeIf { isVar }?.let { IsVar },
+                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { isCompanionBlock },
                 )
             }
         )

--- a/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiUtil.kt
+++ b/dokka-subprojects/analysis-java-psi/src/main/kotlin/org/jetbrains/dokka/analysis/java/util/PsiUtil.kt
@@ -4,6 +4,7 @@
 
 package org.jetbrains.dokka.analysis.java.util
 
+import com.intellij.lang.jvm.JvmModifier
 import com.intellij.psi.*
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.dokka.InternalDokkaApi
@@ -47,8 +48,11 @@ public fun DRI.Companion.from(psi: PsiElement): DRI = psi.parentsWithSelf.run {
 internal fun Callable.Companion.from(psi: PsiMethod) = with(psi) {
     Callable(
         name,
-        null,
-        parameterList.parameters.map { param -> JavaClassReference(param.type.canonicalText) })
+        receiver = null,
+        params = parameterList.parameters.map { param -> JavaClassReference(param.type.canonicalText) },
+        isProperty = false,
+        isCompanion = hasModifier(JvmModifier.STATIC)
+    )
 }
 
 internal fun Callable.Companion.from(psi: PsiField): Callable {
@@ -56,7 +60,8 @@ internal fun Callable.Companion.from(psi: PsiField): Callable {
         name = psi.name,
         receiver = null,
         params = emptyList(),
-        isProperty = true
+        isProperty = true,
+        isCompanion = psi.hasModifier(JvmModifier.STATIC)
     )
 }
 

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DRIFactory.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DRIFactory.kt
@@ -21,7 +21,13 @@ internal fun ClassId.createDRI(): DRI = DRI(
     packageName = this.packageFqName.asString(), classNames = this.relativeClassName.asString()
 )
 
-private fun CallableId.createDRI(receiver: TypeReference?, params: List<TypeReference>, contextParams: List<TypeReference>, isProperty: Boolean): DRI = DRI(
+private fun CallableId.createDRI(
+    receiver: TypeReference?,
+    params: List<TypeReference>,
+    contextParams: List<TypeReference>,
+    isProperty: Boolean,
+    isCompanion: Boolean
+): DRI = DRI(
     packageName = this.packageName.asString(),
     classNames = this.className?.asString(),
     callable = Callable(
@@ -29,7 +35,8 @@ private fun CallableId.createDRI(receiver: TypeReference?, params: List<TypeRefe
         params = params,
         receiver = receiver,
         contextParameters = contextParams,
-        isProperty = isProperty
+        isProperty = isProperty,
+        isCompanion = isCompanion
     )
 )
 
@@ -70,7 +77,7 @@ internal fun KaSession.getDRIFromVariable(symbol: KaVariableSymbol): DRI {
     val callableId = symbol.callableId ?: throw IllegalStateException("Can not get callable Id due to it is local")
     val receiver = symbol.receiverType?.let(::getTypeReferenceFrom)
     val contextParams = @OptIn(KaExperimentalApi::class) symbol.contextParameters.map { getTypeReferenceFrom(it.returnType) }
-    return callableId.createDRI(receiver, emptyList(), contextParams, true)
+    return callableId.createDRI(receiver, emptyList(), contextParams, true, @OptIn(KaExperimentalApi::class) symbol.isCompanion)
 }
 
 
@@ -85,7 +92,7 @@ internal fun KaSession.getDRIFromFunction(symbol: KaFunctionSymbol): DRI {
     val receiver = symbol.receiverType?.let {
         getTypeReferenceFrom(it)
     }
-    return symbol.callableId?.createDRI(receiver, params, contextParams, false) ?: getDRIFromLocalFunction(symbol)
+    return symbol.callableId?.createDRI(receiver, params, contextParams, false, @OptIn(KaExperimentalApi::class) symbol.isCompanion) ?: getDRIFromLocalFunction(symbol)
 }
 
 internal fun getDRIFromClassLike(symbol: KaClassLikeSymbol): DRI =

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
@@ -575,7 +575,7 @@ internal class DokkaSymbolVisitor(
 
                         IsAlsoParameter(listOf(sourceSet))
                     },
-                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { @OptIn(KaExperimentalApi::class) propertySymbol.isCompanion },
+                    @OptIn(ExperimentalDokkaApi::class) IsCompanion.takeIf { @OptIn(KaExperimentalApi::class) propertySymbol.isCompanion },
                 )
             )
         }
@@ -619,7 +619,7 @@ internal class DokkaSymbolVisitor(
                     inheritedFrom?.let { InheritedMember(it.toSourceSetDependent()) },
                     // non-final java property should be var
                     takeUnless { javaFieldSymbol.isVal }?.let { IsVar },
-                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { @OptIn(KaExperimentalApi::class) javaFieldSymbol.isCompanion },
+                    @OptIn(ExperimentalDokkaApi::class) IsCompanion.takeIf { @OptIn(KaExperimentalApi::class) javaFieldSymbol.isCompanion },
                 )
             )
         }
@@ -793,7 +793,7 @@ internal class DokkaSymbolVisitor(
                         ?.toSourceSetDependent()?.toAnnotations(),
                     ObviousMember.takeIf { isObvious(functionSymbol, inheritedFrom) },
                     getCheckedExceptions(functionSymbol),
-                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { @OptIn(KaExperimentalApi::class) functionSymbol.isCompanion },
+                    @OptIn(ExperimentalDokkaApi::class) IsCompanion.takeIf { @OptIn(KaExperimentalApi::class) functionSymbol.isCompanion },
                 )
             )
         }

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/translators/DefaultSymbolToDocumentableTranslator.kt
@@ -574,7 +574,8 @@ internal class DokkaSymbolVisitor(
                             inheritedFrom == null }?.let {
 
                         IsAlsoParameter(listOf(sourceSet))
-                    }
+                    },
+                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { @OptIn(KaExperimentalApi::class) propertySymbol.isCompanion },
                 )
             )
         }
@@ -617,7 +618,8 @@ internal class DokkaSymbolVisitor(
                     getJavaConstantExpression(javaFieldSymbol)?.let { DefaultValue(it.toSourceSetDependent()) },
                     inheritedFrom?.let { InheritedMember(it.toSourceSetDependent()) },
                     // non-final java property should be var
-                    takeUnless { javaFieldSymbol.isVal }?.let { IsVar }
+                    takeUnless { javaFieldSymbol.isVal }?.let { IsVar },
+                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { @OptIn(KaExperimentalApi::class) javaFieldSymbol.isCompanion },
                 )
             )
         }
@@ -791,6 +793,7 @@ internal class DokkaSymbolVisitor(
                         ?.toSourceSetDependent()?.toAnnotations(),
                     ObviousMember.takeIf { isObvious(functionSymbol, inheritedFrom) },
                     getCheckedExceptions(functionSymbol),
+                    @OptIn(ExperimentalDokkaApi::class) CompanionBlockMember.takeIf { @OptIn(KaExperimentalApi::class) functionSymbol.isCompanion },
                 )
             )
         }

--- a/dokka-subprojects/core/api/dokka-core.api
+++ b/dokka-subprojects/core/api/dokka-core.api
@@ -894,13 +894,6 @@ public final class org/jetbrains/dokka/model/ClassValue : org/jetbrains/dokka/mo
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class org/jetbrains/dokka/model/CompanionBlockMember : org/jetbrains/dokka/model/properties/ExtraProperty, org/jetbrains/dokka/model/properties/ExtraProperty$Key {
-	public static final field INSTANCE Lorg/jetbrains/dokka/model/CompanionBlockMember;
-	public fun getKey ()Lorg/jetbrains/dokka/model/properties/ExtraProperty$Key;
-	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/CompanionBlockMember;Lorg/jetbrains/dokka/model/CompanionBlockMember;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
-}
-
 public final class org/jetbrains/dokka/model/ComplexExpression : org/jetbrains/dokka/model/Expression {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -1888,6 +1881,13 @@ public final class org/jetbrains/dokka/model/IsAlsoParameter : org/jetbrains/dok
 public final class org/jetbrains/dokka/model/IsAlsoParameter$Companion : org/jetbrains/dokka/model/properties/ExtraProperty$Key {
 	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/IsAlsoParameter;Lorg/jetbrains/dokka/model/IsAlsoParameter;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
+}
+
+public final class org/jetbrains/dokka/model/IsCompanion : org/jetbrains/dokka/model/properties/ExtraProperty, org/jetbrains/dokka/model/properties/ExtraProperty$Key {
+	public static final field INSTANCE Lorg/jetbrains/dokka/model/IsCompanion;
+	public fun getKey ()Lorg/jetbrains/dokka/model/properties/ExtraProperty$Key;
+	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
+	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/IsCompanion;Lorg/jetbrains/dokka/model/IsCompanion;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
 public final class org/jetbrains/dokka/model/IsVar : org/jetbrains/dokka/model/properties/ExtraProperty, org/jetbrains/dokka/model/properties/ExtraProperty$Key {

--- a/dokka-subprojects/core/api/dokka-core.api
+++ b/dokka-subprojects/core/api/dokka-core.api
@@ -483,25 +483,31 @@ public final class org/jetbrains/dokka/links/Callable {
 	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lorg/jetbrains/dokka/links/TypeReference;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Z
+	public final fun component6 ()Z
 	public final synthetic fun copy (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;)Lorg/jetbrains/dokka/links/Callable;
 	public final synthetic fun copy (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;)Lorg/jetbrains/dokka/links/Callable;
-	public final fun copy (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;Z)Lorg/jetbrains/dokka/links/Callable;
+	public final synthetic fun copy (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;Z)Lorg/jetbrains/dokka/links/Callable;
+	public final fun copy (Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;ZZ)Lorg/jetbrains/dokka/links/Callable;
 	public static synthetic fun copy$default (Lorg/jetbrains/dokka/links/Callable;Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/dokka/links/Callable;
 	public static synthetic fun copy$default (Lorg/jetbrains/dokka/links/Callable;Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/dokka/links/Callable;
 	public static synthetic fun copy$default (Lorg/jetbrains/dokka/links/Callable;Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lorg/jetbrains/dokka/links/Callable;
+	public static synthetic fun copy$default (Lorg/jetbrains/dokka/links/Callable;Ljava/lang/String;Lorg/jetbrains/dokka/links/TypeReference;Ljava/util/List;Ljava/util/List;ZZILjava/lang/Object;)Lorg/jetbrains/dokka/links/Callable;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContextParameters ()Ljava/util/List;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getParams ()Ljava/util/List;
 	public final fun getReceiver ()Lorg/jetbrains/dokka/links/TypeReference;
 	public fun hashCode ()I
+	public final fun isCompanion ()Z
 	public final fun isProperty ()Z
 	public final fun signature ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
@@ -886,6 +892,13 @@ public final class org/jetbrains/dokka/model/ClassValue : org/jetbrains/dokka/mo
 	public final fun getClassName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/dokka/model/CompanionBlockMember : org/jetbrains/dokka/model/properties/ExtraProperty, org/jetbrains/dokka/model/properties/ExtraProperty$Key {
+	public static final field INSTANCE Lorg/jetbrains/dokka/model/CompanionBlockMember;
+	public fun getKey ()Lorg/jetbrains/dokka/model/properties/ExtraProperty$Key;
+	public synthetic fun mergeStrategyFor (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
+	public fun mergeStrategyFor (Lorg/jetbrains/dokka/model/CompanionBlockMember;Lorg/jetbrains/dokka/model/CompanionBlockMember;)Lorg/jetbrains/dokka/model/properties/MergeStrategy;
 }
 
 public final class org/jetbrains/dokka/model/ComplexExpression : org/jetbrains/dokka/model/Expression {

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
@@ -89,7 +89,19 @@ public data class Callable(
     val params: List<TypeReference>,
     @property:ExperimentalDokkaApi
     val contextParameters: List<TypeReference> = emptyList(),
-    val isProperty: Boolean = false
+    val isProperty: Boolean = false,
+    /**
+     * Distinguishes callables that do not have an instance receiver from instance ones.
+     *
+     * `true` for:
+     * - Java static methods/fields
+     * - Enum synthetic declarations (`values`, `valueOf`, `entries`)
+     * - Kotlin companion-block members (see [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md))
+     *
+     * @see org.jetbrains.dokka.model.CompanionBlockMember
+     */
+    @property:ExperimentalDokkaApi
+    val isCompanion: Boolean = false,
 ) {
     init {
         if (isProperty) require(
@@ -128,17 +140,39 @@ public data class Callable(
         contextParameters: List<TypeReference>
     ): Callable = Callable(name, receiver, params, contextParameters)
 
+    @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+    public constructor(
+        name: String,
+        receiver: TypeReference? = null,
+        params: List<TypeReference>,
+        contextParameters: List<TypeReference>,
+        isProperty: Boolean,
+    ) : this(name, receiver, params, contextParameters, isProperty, isCompanion = false)
+
+    @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+    public fun copy(
+        name: String = this.name,
+        receiver: TypeReference? = this.receiver,
+        params: List<TypeReference> = this.params,
+        contextParameters: List<TypeReference>,
+        isProperty: Boolean,
+    ): Callable = Callable(name, receiver, params, contextParameters, isProperty, isCompanion = false)
+
     public fun signature(): String {
         /**
          * Compatibility with [signature] without context parameters must be preserved,
          * as package-list (e.g. `DefaultExternalLocationProvider` in the base plugin) and unit tests
-         * rely on `dri.toString`
+         * rely on `dri.toString`.
+         *
+         * The `static` marker is appended only when [isCompanion] is `true` to preserve the existing
+         * signature of regular instance callables.
          */
         val contextParameters = @OptIn(ExperimentalDokkaApi::class) contextParameters
-        return if (contextParameters.isNotEmpty())
+        val base = if (contextParameters.isNotEmpty())
             "${contextParameters.joinToString("#")}#${receiver?.toString().orEmpty()}#${params.joinToString("#")}"
         else
             "${receiver?.toString().orEmpty()}#${params.joinToString("#")}"
+        return if (@OptIn(ExperimentalDokkaApi::class) isCompanion) "$base/static" else base
     }
 
     public companion object

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
@@ -97,6 +97,7 @@ public data class Callable(
      * - Java static methods/fields
      * - Enum synthetic declarations (`values`, `valueOf`, `entries`)
      * - Kotlin companion-block members (see [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md))
+     * - Kotlin companion extensions (see [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md))
      *
      * @see org.jetbrains.dokka.model.CompanionBlockMember
      */

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
@@ -173,7 +173,7 @@ public data class Callable(
             "${contextParameters.joinToString("#")}#${receiver?.toString().orEmpty()}#${params.joinToString("#")}"
         else
             "${receiver?.toString().orEmpty()}#${params.joinToString("#")}"
-        return if (@OptIn(ExperimentalDokkaApi::class) isCompanion) "$base/static" else base
+        return if (@OptIn(ExperimentalDokkaApi::class) isCompanion) "$base/companion" else base
     }
 
     public companion object

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/links/DRI.kt
@@ -99,7 +99,7 @@ public data class Callable(
      * - Kotlin companion-block members (see [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md))
      * - Kotlin companion extensions (see [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md))
      *
-     * @see org.jetbrains.dokka.model.CompanionBlockMember
+     * @see org.jetbrains.dokka.model.IsCompanion
      */
     @property:ExperimentalDokkaApi
     val isCompanion: Boolean = false,

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/documentableProperties.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/documentableProperties.kt
@@ -5,6 +5,7 @@
 package org.jetbrains.dokka.model
 
 import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
+import org.jetbrains.dokka.ExperimentalDokkaApi
 import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.properties.ExtraProperty
 import org.jetbrains.dokka.model.properties.MergeStrategy
@@ -40,6 +41,26 @@ public data class ExceptionInSupertypes(val exceptions: SourceSetDependent<List<
 }
 
 public object ObviousMember : ExtraProperty<Documentable>, ExtraProperty.Key<Documentable, ObviousMember> {
+    override val key: ExtraProperty.Key<Documentable, *> = this
+}
+
+/**
+ * Marks a callable as belonging to the "companion block" scope of its enclosing classlike,
+ * meaning it has no instance receiver from the enclosing class.
+ *
+ *
+ * This covers, in a unified way:
+ * - Java `static` methods and fields
+ * - Enum synthetic declarations (`values`, `valueOf`, `entries`)
+ * - Kotlin companion-block members
+ *   (see [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md))
+ *
+ * The same condition is reflected in the [org.jetbrains.dokka.links.Callable.isCompanion]
+ * field of the [DRI] so that companion and instance callables with the same name
+ * can be distinguished by their DRI signature.
+ */
+@ExperimentalDokkaApi
+public object CompanionBlockMember : ExtraProperty<Documentable>, ExtraProperty.Key<Documentable, CompanionBlockMember> {
     override val key: ExtraProperty.Key<Documentable, *> = this
 }
 

--- a/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/documentableProperties.kt
+++ b/dokka-subprojects/core/src/main/kotlin/org/jetbrains/dokka/model/documentableProperties.kt
@@ -54,13 +54,15 @@ public object ObviousMember : ExtraProperty<Documentable>, ExtraProperty.Key<Doc
  * - Enum synthetic declarations (`values`, `valueOf`, `entries`)
  * - Kotlin companion-block members
  *   (see [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md))
+ * - Kotlin companion extensions
+ *   (see [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md))
  *
  * The same condition is reflected in the [org.jetbrains.dokka.links.Callable.isCompanion]
  * field of the [DRI] so that companion and instance callables with the same name
  * can be distinguished by their DRI signature.
  */
 @ExperimentalDokkaApi
-public object CompanionBlockMember : ExtraProperty<Documentable>, ExtraProperty.Key<Documentable, CompanionBlockMember> {
+public object IsCompanion : ExtraProperty<Documentable>, ExtraProperty.Key<Documentable, IsCompanion> {
     override val key: ExtraProperty.Key<Documentable, *> = this
 }
 

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
@@ -72,15 +72,15 @@ public class KotlinSignatureProvider(
      * Only such declarations carry the `companion` keyword in their source form
      * (and therefore in their rendered Kotlin signature). Companion-block members
      * (declarations inside `companion { ... }`), Java statics, and enum synthetic
-     * declarations also carry [CompanionBlockMember], but they have no receiver
+     * declarations also carry [IsCompanion], but they have no receiver
      * and do not use the `companion` keyword in source — they are excluded here.
      */
     private fun DFunction.isCompanionExtension(): Boolean {
-        @OptIn(ExperimentalDokkaApi::class) return receiver != null && extra[CompanionBlockMember] != null
+        @OptIn(ExperimentalDokkaApi::class) return receiver != null && extra[IsCompanion] != null
     }
 
     private fun DProperty.isCompanionExtension(): Boolean {
-        @OptIn(ExperimentalDokkaApi::class) return receiver != null && extra[CompanionBlockMember] != null
+        @OptIn(ExperimentalDokkaApi::class) return receiver != null && extra[IsCompanion] != null
     }
 
     private fun <T> PageContentBuilder.DocumentableContentBuilder.modifier(

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/signatures/KotlinSignatureProvider.kt
@@ -65,6 +65,24 @@ public class KotlinSignatureProvider(
             ?.contains(ExtraModifiers.KotlinOnlyModifiers.Data) == true
     }
 
+    /**
+     * Whether this callable is a KEEP-0449 companion extension — a top-level
+     * extension function/property declared with the `companion` modifier.
+     *
+     * Only such declarations carry the `companion` keyword in their source form
+     * (and therefore in their rendered Kotlin signature). Companion-block members
+     * (declarations inside `companion { ... }`), Java statics, and enum synthetic
+     * declarations also carry [CompanionBlockMember], but they have no receiver
+     * and do not use the `companion` keyword in source — they are excluded here.
+     */
+    private fun DFunction.isCompanionExtension(): Boolean {
+        @OptIn(ExperimentalDokkaApi::class) return receiver != null && extra[CompanionBlockMember] != null
+    }
+
+    private fun DProperty.isCompanionExtension(): Boolean {
+        @OptIn(ExperimentalDokkaApi::class) return receiver != null && extra[CompanionBlockMember] != null
+    }
+
     private fun <T> PageContentBuilder.DocumentableContentBuilder.modifier(
         documentable: T,
         sourceSet: DokkaSourceSet
@@ -280,6 +298,7 @@ public class KotlinSignatureProvider(
                 }
                 p.visibility[sourceSet].takeIf { it !in ignoredVisibilities }?.name?.let { keyword("$it ") }
                 if (p.isExpectActual) keyword(if (sourceSet == p.expectPresentInSet) "expect " else "actual ")
+                if (p.isCompanionExtension()) keyword("companion ")
                 modifier(p, sourceSet)
                 p.modifiers()[sourceSet]?.toSignatureString()?.takeIf { it.isNotEmpty() }?.let { keyword(it) }
                 if (p.isMutable()) keyword("var ") else keyword("val ")
@@ -346,6 +365,7 @@ public class KotlinSignatureProvider(
                 if (f.isConstructor) {
                     keyword("constructor")
                 } else {
+                    if (f.isCompanionExtension()) keyword("companion ")
                     modifier(f, sourceSet)
                     f.modifiers()[sourceSet]?.toSignatureString()?.takeIf { it.isNotEmpty() }?.let { keyword(it) }
                     keyword("fun ")

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
@@ -5,6 +5,7 @@
 package org.jetbrains.dokka.base.translators.documentables
 
 import org.jetbrains.dokka.DokkaConfiguration.DokkaSourceSet
+import org.jetbrains.dokka.ExperimentalDokkaApi
 import org.jetbrains.dokka.Platform
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
 import org.jetbrains.dokka.base.resolvers.anchors.SymbolAnchorHint
@@ -416,20 +417,33 @@ public open class DefaultPageCreator(
         extensions: List<Documentable>,
     ) = contentBuilder.contentFor(dri, sourceSets) {
         typesBlock(types)
+
         val (extensionProperties, extensionFunctions) = extensions.splitPropsAndFuns()
+
+        // Companion-block scope members (Java statics, enum synthetic, KEEP-0449 companion blocks)
+        // are rendered right after Types and before instance Functions/Properties.
+        val (companionExtensionFunctions, extensionInstanceFunctions) = extensionFunctions.partition { it.isCompanionBlock() }
+        val (companionExtensionProperties, extensionInstanceProperties) = extensionProperties.partition { it.isCompanionBlock() }
+
+        val (companionFunctions, instanceFunctions) = functions.partition { it.isCompanionBlock() }
+        val (companionProperties, instanceProperties) = properties.partition { it.isCompanionBlock() }
+
+        companionPropertiesBlock(companionProperties, companionExtensionProperties)
+        companionFunctionsBlock(companionFunctions, companionExtensionFunctions)
+
         if (separateInheritedMembers) {
-            val (inheritedFunctions, memberFunctions) = functions.splitInherited()
-            val (inheritedProperties, memberProperties) = properties.splitInherited()
+            val (inheritedFunctions, memberFunctions) = instanceFunctions.splitInherited()
+            val (inheritedProperties, memberProperties) = instanceProperties.splitInherited()
 
             val (
                 inheritedExtensionFunctions,
                 directExtensionFunctions
-            ) = extensionFunctions.splitInheritedExtension(dri)
+            ) = extensionInstanceFunctions.splitInheritedExtension(dri)
 
             val (
                 inheritedExtensionProperties,
                 directExtensionProperties
-            ) = extensionProperties.splitInheritedExtension(dri)
+            ) = extensionInstanceProperties.splitInheritedExtension(dri)
 
             propertiesBlock("Properties", memberProperties, directExtensionProperties)
             propertiesBlock("Inherited properties", inheritedProperties, inheritedExtensionProperties)
@@ -437,10 +451,15 @@ public open class DefaultPageCreator(
             functionsBlock("Functions", memberFunctions, directExtensionFunctions)
             functionsBlock("Inherited functions", inheritedFunctions, inheritedExtensionFunctions)
         } else {
-            propertiesBlock("Properties", properties, extensionProperties)
-            functionsBlock("Functions", functions, extensionFunctions)
+            propertiesBlock("Properties", instanceProperties, extensionInstanceProperties)
+            functionsBlock("Functions", instanceFunctions, extensionInstanceFunctions)
         }
     }
+
+    private fun <T> T.isCompanionBlock(): Boolean where T : Documentable, T : WithExtraProperties<T> {
+        @OptIn(ExperimentalDokkaApi::class) return extra[CompanionBlockMember] != null
+    }
+
 
     /**
      * @param documentables a list of [DClasslike] and [DEnumEntry] and [DTypeAlias] with the same dri in different sourceSets
@@ -675,6 +694,32 @@ public open class DefaultPageCreator(
             },
             declarations = declarations,
             extensions = extensions
+        )
+    }
+
+    private fun DocumentableContentBuilder.companionFunctionsBlock(declarations: List<DFunction>, extensions: List<DFunction>) {
+        functionsOrPropertiesBlock(
+            name = "Companion functions",
+            contentKind = ContentKind.Functions,
+            contentType = when {
+                declarations.isEmpty() -> BasicTabbedContentType.EXTENSION_PROPERTY
+                else -> BasicTabbedContentType.PROPERTY
+            },
+            declarations = declarations,
+            extensions = extensions,
+        )
+    }
+
+    private fun DocumentableContentBuilder.companionPropertiesBlock(declarations: List<DProperty>, extensions: List<DProperty>) {
+        functionsOrPropertiesBlock(
+            name = "Companion properties",
+            contentKind = ContentKind.Properties,
+            contentType = when {
+                declarations.isEmpty() -> BasicTabbedContentType.EXTENSION_PROPERTY
+                else -> BasicTabbedContentType.PROPERTY
+            },
+            declarations = declarations,
+            extensions = extensions,
         )
     }
 

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
@@ -702,8 +702,8 @@ public open class DefaultPageCreator(
             name = "Companion functions",
             contentKind = ContentKind.Functions,
             contentType = when {
-                declarations.isEmpty() -> BasicTabbedContentType.EXTENSION_PROPERTY
-                else -> BasicTabbedContentType.PROPERTY
+                declarations.isEmpty() -> BasicTabbedContentType.EXTENSION_FUNCTION
+                else -> BasicTabbedContentType.FUNCTION
             },
             declarations = declarations,
             extensions = extensions,

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
@@ -422,11 +422,11 @@ public open class DefaultPageCreator(
 
         // Companion-block scope members (Java statics, enum synthetic, KEEP-0449 companion blocks)
         // are rendered right after Types and before instance Functions/Properties.
-        val (companionExtensionFunctions, extensionInstanceFunctions) = extensionFunctions.partition { it.isCompanionBlock() }
-        val (companionExtensionProperties, extensionInstanceProperties) = extensionProperties.partition { it.isCompanionBlock() }
+        val (companionExtensionFunctions, extensionInstanceFunctions) = extensionFunctions.partition { it.isCompanion() }
+        val (companionExtensionProperties, extensionInstanceProperties) = extensionProperties.partition { it.isCompanion() }
 
-        val (companionFunctions, instanceFunctions) = functions.partition { it.isCompanionBlock() }
-        val (companionProperties, instanceProperties) = properties.partition { it.isCompanionBlock() }
+        val (companionFunctions, instanceFunctions) = functions.partition { it.isCompanion() }
+        val (companionProperties, instanceProperties) = properties.partition { it.isCompanion() }
 
         companionPropertiesBlock(companionProperties, companionExtensionProperties)
         companionFunctionsBlock(companionFunctions, companionExtensionFunctions)
@@ -456,7 +456,7 @@ public open class DefaultPageCreator(
         }
     }
 
-    private fun <T> T.isCompanionBlock(): Boolean where T : Documentable, T : WithExtraProperties<T> {
+    private fun <T> T.isCompanion(): Boolean where T : Documentable, T : WithExtraProperties<T>, T : org.jetbrains.dokka.model.Callable {
         @OptIn(ExperimentalDokkaApi::class) return extra[IsCompanion] != null
     }
 

--- a/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
+++ b/dokka-subprojects/plugin-base/src/main/kotlin/org/jetbrains/dokka/base/translators/documentables/DefaultPageCreator.kt
@@ -457,7 +457,7 @@ public open class DefaultPageCreator(
     }
 
     private fun <T> T.isCompanionBlock(): Boolean where T : Documentable, T : WithExtraProperties<T> {
-        @OptIn(ExperimentalDokkaApi::class) return extra[CompanionBlockMember] != null
+        @OptIn(ExperimentalDokkaApi::class) return extra[IsCompanion] != null
     }
 
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/basic/DRITest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/basic/DRITest.kt
@@ -554,11 +554,11 @@ class DRITest : BaseAbstractTest() {
 
     @Test
     fun `Callable signature distinguishes static from instance for same-name callables`() {
-        val instance = org.jetbrains.dokka.links.Callable("foo", receiver = null, params = emptyList(), isCompanion = false)
-        val static = org.jetbrains.dokka.links.Callable("foo", receiver = null, params = emptyList(), isCompanion = true)
+        val instance = Callable("foo", receiver = null, params = emptyList(), isCompanion = false)
+        val static = Callable("foo", receiver = null, params = emptyList(), isCompanion = true)
 
         assertTrue(instance.signature() != static.signature(), "static and instance signatures must differ")
-        assertTrue(static.signature().endsWith("/static"))
+        assertTrue(static.signature().endsWith("/companion"))
 
         // an existing instance member DRI's signature must remain unchanged
         assertEquals("#", instance.signature())

--- a/dokka-subprojects/plugin-base/src/test/kotlin/basic/DRITest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/basic/DRITest.kt
@@ -16,6 +16,7 @@ import org.jetbrains.dokka.pages.MemberPageNode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class DRITest : BaseAbstractTest() {
     private val defaultConfiguration = dokkaConfiguration {
@@ -549,5 +550,17 @@ class DRITest : BaseAbstractTest() {
                 )
             }
         }
+    }
+
+    @Test
+    fun `Callable signature distinguishes static from instance for same-name callables`() {
+        val instance = org.jetbrains.dokka.links.Callable("foo", receiver = null, params = emptyList(), isCompanion = false)
+        val static = org.jetbrains.dokka.links.Callable("foo", receiver = null, params = emptyList(), isCompanion = true)
+
+        assertTrue(instance.signature() != static.signature(), "static and instance signatures must differ")
+        assertTrue(static.signature().endsWith("/static"))
+
+        // an existing instance member DRI's signature must remain unchanged
+        assertEquals("#", instance.signature())
     }
 }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/enums/KotlinEnumsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/enums/KotlinEnumsTest.kt
@@ -361,7 +361,8 @@ class KotlinEnumsTest : BaseAbstractTest() {
                 }
 
                 root.contentPage<ClasslikePageNode>("TestEnum") {
-                    assertHasFunctions("toBeImplemented", "valueOf", "values")
+                    assertHasFunctions("toBeImplemented")
+                    assertHasCompanionFunctions("valueOf", "values")
                 }
             }
         }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/enums/KotlinEnumsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/enums/KotlinEnumsTest.kt
@@ -328,6 +328,7 @@ class KotlinEnumsTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("companion block")
     fun `enum should have functions on page`() {
         val configuration = dokkaConfiguration {
             sourceSets {

--- a/dokka-subprojects/plugin-base/src/test/kotlin/enums/KotlinEnumsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/enums/KotlinEnumsTest.kt
@@ -370,6 +370,37 @@ class KotlinEnumsTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("companion block")
+    fun `enum should have entries property`() {
+        val configuration = dokkaConfiguration {
+            sourceSets {
+                sourceSet {
+                    sourceRoots = listOf("src/")
+                    classpath = listOf(commonStdlibPath!!, jvmStdlibPath!!)
+                }
+            }
+        }
+
+        testInline(
+            """
+            |/src/main/kotlin/basic/TestEnum.kt
+            |package testpackage
+            |
+            |enum class TestEnum {
+            |    FOO, BAR;
+            |}
+        """.trimMargin(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                root.contentPage<ClasslikePageNode>("TestEnum") {
+                    assertHasCompanionProperty("entries")
+                }
+            }
+        }
+    }
+
+    @Test
     fun enumWithAnnotationsOnEntries() {
         val configuration = dokkaConfiguration {
             sourceSets {

--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
@@ -1697,6 +1697,7 @@ class LinkTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("companion block - Java static is marked as companion")
     fun `should resolve KDoc links that goes after markdown blocks`() {
         testInline(
             """

--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
@@ -1719,7 +1719,8 @@ class LinkTest : BaseAbstractTest() {
                             "java.lang", "System", Callable(
                                 "currentTimeMillis",
                                 receiver = null,
-                                params = emptyList()
+                                params = emptyList(),
+                                isCompanion = true
                             )
                         ),
                         "JavaNetCookieJar" to DRI("example", "JavaNetCookieJar"),

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
@@ -12,6 +12,7 @@ import org.jetbrains.dokka.model.DClass
 import org.jetbrains.dokka.model.DEnum
 import org.jetbrains.dokka.model.DFunction
 import utils.AbstractModelTest
+import utils.OnlySymbols
 import utils.assertNotNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -28,6 +29,7 @@ import kotlin.test.assertTrue
  *
  * See [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md).
  */
+@OnlySymbols("companion block")
 class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.kt", "companions") {
 
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+@file:OptIn(ExperimentalDokkaApi::class)
+
+package model
+
+import org.jetbrains.dokka.ExperimentalDokkaApi
+import org.jetbrains.dokka.model.CompanionBlockMember
+import org.jetbrains.dokka.model.DClass
+import org.jetbrains.dokka.model.DEnum
+import org.jetbrains.dokka.model.DFunction
+import utils.AbstractModelTest
+import utils.assertNotNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for KEEP-0449 companion blocks: members declared inside a `companion { ... }`
+ * block (no `object` keyword) live in the static scope of the enclosing classlike.
+ *
+ * They are represented in Dokka in the same way as Java static declarations and
+ * enum synthetic declarations (`values` / `valueOf` / `entries`):
+ *   - the [org.jetbrains.dokka.links.DRI]'s [org.jetbrains.dokka.links.Callable.isCompanion] is `true`
+ *   - the documentable carries [CompanionBlockMember] in its extra container
+ *
+ * See [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md).
+ */
+class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.kt", "companions") {
+
+
+    @Test
+    fun `companion-block function is marked as companion-block member`() {
+        inlineModelTest(
+            """
+            |class Vector(val x: Double, val y: Double) {
+            |    companion {
+            |        fun unit(): Vector = Vector(1.0, 1.0)
+            |    }
+            |}
+            """.trimIndent()
+        ) {
+            with((this / "companions" / "Vector").cast<DClass>()) {
+                val unit = functions.firstOrNull { it.name == "unit" }
+                    .assertNotNull("companion-block function 'unit'")
+                unit.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'unit'")
+                assertEquals(true, @OptIn(ExperimentalDokkaApi::class) unit.dri.callable?.isCompanion, "DRI for 'unit' should be marked isStatic=true")
+            }
+        }
+    }
+
+    @Test
+    fun `companion-block property is marked as companion-block member`() {
+        inlineModelTest(
+            """
+            |class Vector(val x: Double, val y: Double) {
+            |    companion {
+            |        val Zero: Vector = Vector(0.0, 0.0)
+            |        const val Dimensions: Int = 2
+            |    }
+            |}
+            """.trimIndent()
+        ) {
+            with((this / "companions" / "Vector").cast<DClass>()) {
+                val zero = properties.firstOrNull { it.name == "Zero" }
+                    .assertNotNull("companion-block property 'Zero'")
+                val dimensions = properties.firstOrNull { it.name == "Dimensions" }
+                    .assertNotNull("companion-block property 'Dimensions'")
+
+                zero.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'Zero'")
+                dimensions.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'Dimensions'")
+                assertEquals(true, @OptIn(ExperimentalDokkaApi::class) zero.dri.callable?.isCompanion)
+                assertEquals(true, @OptIn(ExperimentalDokkaApi::class) dimensions.dri.callable?.isCompanion)
+            }
+        }
+    }
+
+    @Test
+    fun `instance member is not marked as companion-block member`() {
+        inlineModelTest(
+            """
+            |class Vector(val x: Double, val y: Double) {
+            |    fun length(): Double = 0.0
+            |    val name: String = "v"
+            |    companion {
+            |        fun unit(): Vector = Vector(1.0, 1.0)
+            |    }
+            |}
+            """.trimIndent()
+        ) {
+            with((this / "companions" / "Vector").cast<DClass>()) {
+                val length = functions.firstOrNull { it.name == "length" }
+                    .assertNotNull("instance function 'length'")
+                val name = properties.firstOrNull { it.name == "name" }
+                    .assertNotNull("instance property 'name'")
+
+                assertEquals(null, length.extra[CompanionBlockMember])
+                assertEquals(false, @OptIn(ExperimentalDokkaApi::class) length.dri.callable?.isCompanion)
+                assertEquals(null, name.extra[CompanionBlockMember])
+                assertEquals(false, @OptIn(ExperimentalDokkaApi::class) name.dri.callable?.isCompanion)
+            }
+        }
+    }
+
+    @Test
+    fun `companion-block and instance with same name have distinct DRIs`() {
+        inlineModelTest(
+            """
+            |class Holder {
+            |    fun foo() {}
+            |    companion {
+            |        @kotlin.jvm.JvmName("fooStatic")
+            |        fun foo() {}
+            |    }
+            |}
+            """.trimIndent()
+        ) {
+            with((this / "companions" / "Holder").cast<DClass>()) {
+                val foos = functions.filter { it.name == "foo" }
+                assertEquals(2, foos.size, "expected an instance and a companion-block 'foo'")
+
+                val instance = foos.single { it.extra[CompanionBlockMember] == null }
+                val companion = foos.single { it.extra[CompanionBlockMember] != null }
+
+                assertEquals(false, @OptIn(ExperimentalDokkaApi::class) instance.dri.callable?.isCompanion)
+                assertEquals(true, @OptIn(ExperimentalDokkaApi::class) companion.dri.callable?.isCompanion)
+                assertTrue(
+                    instance.dri.callable?.signature() != companion.dri.callable?.signature(),
+                    "Callable signatures must differ between instance and companion-block members"
+                )
+                assertEquals(
+                    true,
+                    companion.dri.callable?.signature()?.endsWith("/static"),
+                    "Companion-block signature must end with the /static marker"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `enum synthetic declarations are marked as companion-block members`() {
+        inlineModelTest(
+            """
+            |enum class E { A, B }
+            """.trimIndent()
+        ) {
+            with((this / "companions" / "E").cast<DEnum>()) {
+                val values = functions.firstOrNull { it.name == "values" }
+                    .assertNotNull("synthetic enum function 'values'")
+                val valueOf = functions.firstOrNull { it.name == "valueOf" }
+                    .assertNotNull("synthetic enum function 'valueOf'")
+
+                values.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'values'")
+                valueOf.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'valueOf'")
+                assertEquals(true, @OptIn(ExperimentalDokkaApi::class) values.dri.callable?.isCompanion)
+                assertEquals(true, @OptIn(ExperimentalDokkaApi::class) valueOf.dri.callable?.isCompanion)
+            }
+        }
+    }
+
+    @Test
+    fun `companion object member is not treated as companion-block member`() {
+        inlineModelTest(
+            """
+            |class Holder {
+            |    companion object {
+            |        fun create(): Holder = Holder()
+            |    }
+            |}
+            """.trimIndent()
+        ) {
+            // a `companion object` is rendered as a nested classlike — its members are NOT
+            // companion-block members. They live as functions on the companion object,
+            // not in the enclosing class's static scope.
+            with((this / "companions" / "Holder").cast<DClass>()) {
+                // No companion-block functions on the enclosing class.
+                val staticOnHolder = functions.filter { it.extra[CompanionBlockMember] != null }
+                assertEquals(emptyList(), staticOnHolder)
+                val staticPropsOnHolder = properties.filter { it.extra[CompanionBlockMember] != null }
+                assertEquals(emptyList(), staticPropsOnHolder)
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // KEEP-0449 companion extensions: top-level extensions declared with the
+    // `companion` modifier, e.g. `companion fun Vector.unit(): Vector`.
+    //
+    // They are represented in Dokka the same way as companion-block members:
+    // the documentable carries the [CompanionBlockMember] extra (driven by
+    // the Analysis API's `KaCallableSymbol.isCompanion` flag).
+    // ----------------------------------------------------------------------
+
+    @Test
+    fun `companion extension function is marked as companion-block member`() {
+        inlineModelTest(
+            """
+            |class Vector(val x: Double, val y: Double)
+            |
+            |companion fun Vector.unit(): Vector = Vector(1.0, 1.0)
+            """.trimIndent()
+        ) {
+            val pkg = packages.single()
+            val ext = pkg.functions.firstOrNull { it.name == "unit" }
+                .assertNotNull("top-level companion extension 'unit'")
+            ext.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on companion extension 'unit'")
+            // sanity-check it is in fact an extension: receiver is non-null and resolves to Vector
+            assertTrue(ext.receiver != null, "companion extension must keep its receiver in the documentable")
+        }
+    }
+
+    @Test
+    fun `companion extension property is marked as companion-block member`() {
+        inlineModelTest(
+            """
+            |class Vector(val x: Double, val y: Double)
+            |
+            |companion val Vector.UnitX: Vector get() = Vector(1.0, 0.0)
+            """.trimIndent()
+        ) {
+            val pkg = packages.single()
+            val ext = pkg.properties.firstOrNull { it.name == "UnitX" }
+                .assertNotNull("top-level companion extension property 'UnitX'")
+            ext.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on companion extension 'UnitX'")
+            assertTrue(ext.receiver != null, "companion extension property must keep its receiver")
+        }
+    }
+
+    @Test
+    fun `regular top-level extension is not marked as companion-block member`() {
+        inlineModelTest(
+            """
+            |class Vector(val x: Double, val y: Double)
+            |
+            |fun Vector.length(): Double = 0.0
+            |val Vector.name: String get() = "v"
+            """.trimIndent()
+        ) {
+            val pkg = packages.single()
+            val length = pkg.functions.firstOrNull { it.name == "length" }
+                .assertNotNull("plain extension 'length'")
+            val nameExt = pkg.properties.firstOrNull { it.name == "name" }
+                .assertNotNull("plain extension property 'name'")
+
+            assertEquals(null, @OptIn(ExperimentalDokkaApi::class) length.extra[CompanionBlockMember])
+            assertEquals(null, @OptIn(ExperimentalDokkaApi::class) nameExt.extra[CompanionBlockMember])
+        }
+    }
+
+    @Test
+    fun `companion-block scope is empty when there are only regular extensions`() {
+        inlineModelTest(
+            """
+            |class Vector(val x: Double, val y: Double)
+            |
+            |fun Vector.length(): Double = 0.0
+            """.trimIndent()
+        ) {
+            val pkg = packages.single()
+            val companionExtensions = pkg.functions.filter { it.extra[CompanionBlockMember] != null }
+            assertEquals(emptyList<DFunction>(), companionExtensions)
+        }
+    }
+}

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
@@ -8,7 +8,7 @@ package model
 
 import org.jetbrains.dokka.ExperimentalDokkaApi
 import org.jetbrains.dokka.links.DRI
-import org.jetbrains.dokka.model.CompanionBlockMember
+import org.jetbrains.dokka.model.IsCompanion
 import org.jetbrains.dokka.model.DClass
 import org.jetbrains.dokka.model.DEnum
 import org.jetbrains.dokka.model.DFunction
@@ -27,7 +27,7 @@ import kotlin.test.assertTrue
  * They are represented in Dokka in the same way as Java static declarations and
  * enum synthetic declarations (`values` / `valueOf` / `entries`):
  *   - the [org.jetbrains.dokka.links.DRI]'s [org.jetbrains.dokka.links.Callable.isCompanion] is `true`
- *   - the documentable carries [CompanionBlockMember] in its extra container
+ *   - the documentable carries [IsCompanion] in its extra container
  *
  * See [KEEP-0449](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0449-companions-block-extension.md).
  */
@@ -49,7 +49,7 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
             with((this / "companions" / "Vector").cast<DClass>()) {
                 val unit = functions.firstOrNull { it.name == "unit" }
                     .assertNotNull("companion-block function 'unit'")
-                unit.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'unit'")
+                unit.extra[IsCompanion].assertNotNull("CompanionBlockMember on 'unit'")
                 assertEquals(true, @OptIn(ExperimentalDokkaApi::class) unit.dri.callable?.isCompanion, "DRI for 'unit' should be marked isStatic=true")
             }
         }
@@ -73,8 +73,8 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
                 val dimensions = properties.firstOrNull { it.name == "Dimensions" }
                     .assertNotNull("companion-block property 'Dimensions'")
 
-                zero.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'Zero'")
-                dimensions.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'Dimensions'")
+                zero.extra[IsCompanion].assertNotNull("CompanionBlockMember on 'Zero'")
+                dimensions.extra[IsCompanion].assertNotNull("CompanionBlockMember on 'Dimensions'")
                 assertEquals(true, @OptIn(ExperimentalDokkaApi::class) zero.dri.callable?.isCompanion)
                 assertEquals(true, @OptIn(ExperimentalDokkaApi::class) dimensions.dri.callable?.isCompanion)
             }
@@ -100,9 +100,9 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
                 val name = properties.firstOrNull { it.name == "name" }
                     .assertNotNull("instance property 'name'")
 
-                assertEquals(null, length.extra[CompanionBlockMember])
+                assertEquals(null, length.extra[IsCompanion])
                 assertEquals(false, @OptIn(ExperimentalDokkaApi::class) length.dri.callable?.isCompanion)
-                assertEquals(null, name.extra[CompanionBlockMember])
+                assertEquals(null, name.extra[IsCompanion])
                 assertEquals(false, @OptIn(ExperimentalDokkaApi::class) name.dri.callable?.isCompanion)
             }
         }
@@ -125,8 +125,8 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
                 val foos = functions.filter { it.name == "foo" }
                 assertEquals(2, foos.size, "expected an instance and a companion-block 'foo'")
 
-                val instance = foos.single { it.extra[CompanionBlockMember] == null }
-                val companion = foos.single { it.extra[CompanionBlockMember] != null }
+                val instance = foos.single { it.extra[IsCompanion] == null }
+                val companion = foos.single { it.extra[IsCompanion] != null }
 
                 assertEquals(false, @OptIn(ExperimentalDokkaApi::class) instance.dri.callable?.isCompanion)
                 assertEquals(true, @OptIn(ExperimentalDokkaApi::class) companion.dri.callable?.isCompanion)
@@ -156,8 +156,8 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
                 val valueOf = functions.firstOrNull { it.name == "valueOf" }
                     .assertNotNull("synthetic enum function 'valueOf'")
 
-                values.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'values'")
-                valueOf.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on 'valueOf'")
+                values.extra[IsCompanion].assertNotNull("CompanionBlockMember on 'values'")
+                valueOf.extra[IsCompanion].assertNotNull("CompanionBlockMember on 'valueOf'")
                 assertEquals(true, @OptIn(ExperimentalDokkaApi::class) values.dri.callable?.isCompanion)
                 assertEquals(true, @OptIn(ExperimentalDokkaApi::class) valueOf.dri.callable?.isCompanion)
             }
@@ -180,9 +180,9 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
             // not in the enclosing class's static scope.
             with((this / "companions" / "Holder").cast<DClass>()) {
                 // No companion-block functions on the enclosing class.
-                val staticOnHolder = functions.filter { it.extra[CompanionBlockMember] != null }
+                val staticOnHolder = functions.filter { it.extra[IsCompanion] != null }
                 assertEquals(emptyList(), staticOnHolder)
-                val staticPropsOnHolder = properties.filter { it.extra[CompanionBlockMember] != null }
+                val staticPropsOnHolder = properties.filter { it.extra[IsCompanion] != null }
                 assertEquals(emptyList(), staticPropsOnHolder)
             }
         }
@@ -209,7 +209,7 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
             val pkg = packages.single()
             val ext = pkg.functions.firstOrNull { it.name == "unit" }
                 .assertNotNull("top-level companion extension 'unit'")
-            ext.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on companion extension 'unit'")
+            ext.extra[IsCompanion].assertNotNull("CompanionBlockMember on companion extension 'unit'")
             // sanity-check it is in fact an extension: receiver is non-null and resolves to Vector
             assertTrue(ext.receiver != null, "companion extension must keep its receiver in the documentable")
             assertEquals(GenericTypeConstructor(DRI("companions", "Vector"), emptyList()), ext.receiver?.type)
@@ -228,7 +228,7 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
             val pkg = packages.single()
             val ext = pkg.properties.firstOrNull { it.name == "UnitX" }
                 .assertNotNull("top-level companion extension property 'UnitX'")
-            ext.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on companion extension 'UnitX'")
+            ext.extra[IsCompanion].assertNotNull("CompanionBlockMember on companion extension 'UnitX'")
             assertTrue(ext.receiver != null, "companion extension property must keep its receiver")
             assertEquals(GenericTypeConstructor(DRI("companions", "Vector"), emptyList()), ext.receiver?.type)
         }
@@ -250,8 +250,8 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
             val nameExt = pkg.properties.firstOrNull { it.name == "name" }
                 .assertNotNull("plain extension property 'name'")
 
-            assertEquals(null, @OptIn(ExperimentalDokkaApi::class) length.extra[CompanionBlockMember])
-            assertEquals(null, @OptIn(ExperimentalDokkaApi::class) nameExt.extra[CompanionBlockMember])
+            assertEquals(null, @OptIn(ExperimentalDokkaApi::class) length.extra[IsCompanion])
+            assertEquals(null, @OptIn(ExperimentalDokkaApi::class) nameExt.extra[IsCompanion])
         }
     }
 
@@ -265,7 +265,7 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
             """.trimIndent()
         ) {
             val pkg = packages.single()
-            val companionExtensions = pkg.functions.filter { it.extra[CompanionBlockMember] != null }
+            val companionExtensions = pkg.functions.filter { it.extra[IsCompanion] != null }
             assertEquals(emptyList<DFunction>(), companionExtensions)
         }
     }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
@@ -7,10 +7,12 @@
 package model
 
 import org.jetbrains.dokka.ExperimentalDokkaApi
+import org.jetbrains.dokka.links.DRI
 import org.jetbrains.dokka.model.CompanionBlockMember
 import org.jetbrains.dokka.model.DClass
 import org.jetbrains.dokka.model.DEnum
 import org.jetbrains.dokka.model.DFunction
+import org.jetbrains.dokka.model.GenericTypeConstructor
 import utils.AbstractModelTest
 import utils.OnlySymbols
 import utils.assertNotNull
@@ -210,6 +212,7 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
             ext.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on companion extension 'unit'")
             // sanity-check it is in fact an extension: receiver is non-null and resolves to Vector
             assertTrue(ext.receiver != null, "companion extension must keep its receiver in the documentable")
+            assertEquals(GenericTypeConstructor(DRI("companions", "Vector"), emptyList()), ext.receiver?.type)
         }
     }
 
@@ -227,6 +230,7 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
                 .assertNotNull("top-level companion extension property 'UnitX'")
             ext.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on companion extension 'UnitX'")
             assertTrue(ext.receiver != null, "companion extension property must keep its receiver")
+            assertEquals(GenericTypeConstructor(DRI("companions", "Vector"), emptyList()), ext.receiver?.type)
         }
     }
 

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/CompanionBlockTest.kt
@@ -136,8 +136,8 @@ class CompanionBlockTest : AbstractModelTest("/src/main/kotlin/companions/Test.k
                 )
                 assertEquals(
                     true,
-                    companion.dri.callable?.signature()?.endsWith("/static"),
-                    "Companion-block signature must end with the /static marker"
+                    companion.dri.callable?.signature()?.endsWith("/companion"),
+                    "Companion-block signature must end with the /companion marker"
                 )
             }
         }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/JavaTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/JavaTest.kt
@@ -5,6 +5,7 @@
 package model
 
 import org.jetbrains.dokka.DokkaConfiguration
+import org.jetbrains.dokka.ExperimentalDokkaApi
 import org.jetbrains.dokka.Platform
 import org.jetbrains.dokka.base.signatures.KotlinSignatureUtils.driOrNull
 import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
@@ -474,6 +475,128 @@ class JavaTest : BaseAbstractTest() {
                 }
             }
         }
+    }
+
+    @Test
+    fun `static method is marked as companion-block member`() {
+        testInline(
+            """
+            |/src/java/C.java
+            |package java;
+            |class C {
+            |  public static void foo() {}
+            |}
+            """.trimIndent(), configuration
+        ) {
+            documentablesTransformationStage = { module ->
+                with((module / "java" / "C" / "foo").cast<DFunction>()) {
+                    @OptIn(ExperimentalDokkaApi::class)
+                    extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on Java static method")
+                    assertEquals(
+                        true,
+                        @OptIn(ExperimentalDokkaApi::class) dri.callable?.isCompanion,
+                        "Java static method's DRI.callable should be marked isStatic=true"
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `instance method is not marked as companion-block member`() {
+        testInline(
+            """
+            |/src/java/C.java
+            |package java;
+            |class C {
+            |  public void instanceFoo() {}
+            |}
+            """.trimIndent(), configuration
+        ) {
+            documentablesTransformationStage = { module ->
+                with((module / "java" / "C" / "instanceFoo").cast<DFunction>()) {
+                    @OptIn(ExperimentalDokkaApi::class) assertEquals(null, extra[CompanionBlockMember])
+                    assertEquals(false, @OptIn(ExperimentalDokkaApi::class) dri.callable?.isCompanion)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `static field is marked as companion-block member`() {
+        testInline(
+            """
+            |/src/java/C.java
+            |package java;
+            |class C {
+            |  public static final String s = "x";
+            |  public int i;
+            |}
+            """.trimIndent(), configuration
+        ) {
+            documentablesTransformationStage = { module ->
+                with((module / "java" / "C" / "s").cast<DProperty>()) {
+                    @OptIn(ExperimentalDokkaApi::class)
+                    extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on Java static field")
+                    assertEquals(
+                        true,
+                        @OptIn(ExperimentalDokkaApi::class) dri.callable?.isCompanion,
+                        "Java static field's DRI.callable should be marked isStatic=true"
+                    )
+                }
+                with((module / "java" / "C" / "i").cast<DProperty>()) {
+                    @OptIn(ExperimentalDokkaApi::class) assertEquals(null, extra[CompanionBlockMember])
+                    assertEquals(false, @OptIn(ExperimentalDokkaApi::class) dri.callable?.isCompanion)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `enum synthetic values, valueOf are marked as companion-block members`() {
+        testInline(
+            """
+            |/src/java/E.java
+            |package java;
+            |enum E {
+            |  A, B
+            |}
+            """.trimIndent(), configuration
+        ) {
+            documentablesTransformationStage = { module ->
+                with((module / "java" / "E").cast<DEnum>()) {
+                    val values = functions.firstOrNull { it.name == "values" }
+                        .assertNotNull("synthetic 'values' function")
+                    val valueOf = functions.firstOrNull { it.name == "valueOf" }
+                        .assertNotNull("synthetic 'valueOf' function")
+
+                    @OptIn(ExperimentalDokkaApi::class) values.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on enum 'values'")
+                    @OptIn(ExperimentalDokkaApi::class) valueOf.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on enum 'valueOf'")
+                    assertEquals(
+                        true,
+                        @OptIn(ExperimentalDokkaApi::class) values.dri.callable?.isCompanion,
+                        "DRI for 'values' should be marked isStatic=true"
+                    )
+                    assertEquals(
+                        true,
+                        @OptIn(ExperimentalDokkaApi::class) valueOf.dri.callable?.isCompanion,
+                        "DRI for 'valueOf' should be marked isStatic=true"
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Callable signature distinguishes static from instance for same-name callables`() {
+        val instance = org.jetbrains.dokka.links.Callable("foo", receiver = null, params = emptyList(), isCompanion = false)
+        val static = org.jetbrains.dokka.links.Callable("foo", receiver = null, params = emptyList(), isCompanion = true)
+
+        assertTrue(instance.signature() != static.signature(), "static and instance signatures must differ")
+        assertTrue(static.signature().endsWith("/static"))
+
+        // an existing instance member DRI's signature must remain unchanged
+        assertEquals("#", instance.signature())
     }
 
     @Test

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/JavaTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/JavaTest.kt
@@ -588,18 +588,6 @@ class JavaTest : BaseAbstractTest() {
     }
 
     @Test
-    fun `Callable signature distinguishes static from instance for same-name callables`() {
-        val instance = org.jetbrains.dokka.links.Callable("foo", receiver = null, params = emptyList(), isCompanion = false)
-        val static = org.jetbrains.dokka.links.Callable("foo", receiver = null, params = emptyList(), isCompanion = true)
-
-        assertTrue(instance.signature() != static.signature(), "static and instance signatures must differ")
-        assertTrue(static.signature().endsWith("/static"))
-
-        // an existing instance member DRI's signature must remain unchanged
-        assertEquals("#", instance.signature())
-    }
-
-    @Test
     fun throwsList() {
         testInline(
             """

--- a/dokka-subprojects/plugin-base/src/test/kotlin/model/JavaTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/model/JavaTest.kt
@@ -491,7 +491,7 @@ class JavaTest : BaseAbstractTest() {
             documentablesTransformationStage = { module ->
                 with((module / "java" / "C" / "foo").cast<DFunction>()) {
                     @OptIn(ExperimentalDokkaApi::class)
-                    extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on Java static method")
+                    extra[IsCompanion].assertNotNull("CompanionBlockMember on Java static method")
                     assertEquals(
                         true,
                         @OptIn(ExperimentalDokkaApi::class) dri.callable?.isCompanion,
@@ -515,7 +515,7 @@ class JavaTest : BaseAbstractTest() {
         ) {
             documentablesTransformationStage = { module ->
                 with((module / "java" / "C" / "instanceFoo").cast<DFunction>()) {
-                    @OptIn(ExperimentalDokkaApi::class) assertEquals(null, extra[CompanionBlockMember])
+                    @OptIn(ExperimentalDokkaApi::class) assertEquals(null, extra[IsCompanion])
                     assertEquals(false, @OptIn(ExperimentalDokkaApi::class) dri.callable?.isCompanion)
                 }
             }
@@ -537,7 +537,7 @@ class JavaTest : BaseAbstractTest() {
             documentablesTransformationStage = { module ->
                 with((module / "java" / "C" / "s").cast<DProperty>()) {
                     @OptIn(ExperimentalDokkaApi::class)
-                    extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on Java static field")
+                    extra[IsCompanion].assertNotNull("CompanionBlockMember on Java static field")
                     assertEquals(
                         true,
                         @OptIn(ExperimentalDokkaApi::class) dri.callable?.isCompanion,
@@ -545,7 +545,7 @@ class JavaTest : BaseAbstractTest() {
                     )
                 }
                 with((module / "java" / "C" / "i").cast<DProperty>()) {
-                    @OptIn(ExperimentalDokkaApi::class) assertEquals(null, extra[CompanionBlockMember])
+                    @OptIn(ExperimentalDokkaApi::class) assertEquals(null, extra[IsCompanion])
                     assertEquals(false, @OptIn(ExperimentalDokkaApi::class) dri.callable?.isCompanion)
                 }
             }
@@ -570,8 +570,8 @@ class JavaTest : BaseAbstractTest() {
                     val valueOf = functions.firstOrNull { it.name == "valueOf" }
                         .assertNotNull("synthetic 'valueOf' function")
 
-                    @OptIn(ExperimentalDokkaApi::class) values.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on enum 'values'")
-                    @OptIn(ExperimentalDokkaApi::class) valueOf.extra[CompanionBlockMember].assertNotNull("CompanionBlockMember on enum 'valueOf'")
+                    @OptIn(ExperimentalDokkaApi::class) values.extra[IsCompanion].assertNotNull("CompanionBlockMember on enum 'values'")
+                    @OptIn(ExperimentalDokkaApi::class) valueOf.extra[IsCompanion].assertNotNull("CompanionBlockMember on enum 'valueOf'")
                     assertEquals(
                         true,
                         @OptIn(ExperimentalDokkaApi::class) values.dri.callable?.isCompanion,

--- a/dokka-subprojects/plugin-base/src/test/kotlin/parsers/javadoc/JavadocMarkdownTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/parsers/javadoc/JavadocMarkdownTest.kt
@@ -247,7 +247,9 @@ class JavadocMarkdownTest : BaseAbstractTest() {
                         classNames = "System",
                         callable = Callable(
                             name = "identityHashCode",
-                            params = listOf(JavaClassReference("java.lang.Object"))
+                            params = listOf(JavaClassReference("java.lang.Object")),
+                            isProperty = false,
+                            isCompanion = true
                         )
                     ),
                     (see2Root as See).address
@@ -379,7 +381,8 @@ class JavadocMarkdownTest : BaseAbstractTest() {
                                                 callable = Callable(
                                                     name = "CASE_INSENSITIVE_ORDER",
                                                     params = emptyList(),
-                                                    isProperty = true
+                                                    isProperty = true,
+                                                    isCompanion = true
                                                 )
                                             ),
                                             children = listOf(Text("String#CASE_INSENSITIVE_ORDER"))
@@ -430,7 +433,8 @@ class JavadocMarkdownTest : BaseAbstractTest() {
                                                 callable = Callable(
                                                     name = "CASE_INSENSITIVE_ORDER",
                                                     params = emptyList(),
-                                                    isProperty = true
+                                                    isProperty = true,
+                                                    isCompanion = true
                                                 )
                                             ),
                                             children = listOf(Text("a field"))
@@ -461,7 +465,9 @@ class JavadocMarkdownTest : BaseAbstractTest() {
                                                 classNames = "String",
                                                 callable = Callable(
                                                     name = "copyValueOf",
-                                                    params = listOf(JavaClassReference("char[]"))
+                                                    params = listOf(JavaClassReference("char[]")),
+                                                    isProperty = false,
+                                                    isCompanion = true
                                                 )
                                             ),
                                             children = listOf(Text("String#copyValueOf(char[])"))

--- a/dokka-subprojects/plugin-base/src/test/kotlin/parsers/javadoc/SnippetTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/parsers/javadoc/SnippetTest.kt
@@ -793,7 +793,8 @@ class SnippetTest : BaseAbstractTest() {
                                         callable = Callable(
                                             name = "out",
                                             params = emptyList(),
-                                            isProperty = true
+                                            isProperty = true,
+                                            isCompanion = true
                                         )
                                     ),
                                     children = listOf(Text("System.out"))
@@ -806,7 +807,8 @@ class SnippetTest : BaseAbstractTest() {
                                         callable = Callable(
                                             name = "out",
                                             params = emptyList(),
-                                            isProperty = true
+                                            isProperty = true,
+                                            isCompanion = true
                                         )
                                     ),
                                     children = listOf(Text("System.out"))
@@ -858,7 +860,8 @@ class SnippetTest : BaseAbstractTest() {
                                         callable = Callable(
                                             name = "out",
                                             params = emptyList(),
-                                            isProperty = true
+                                            isProperty = true,
+                                            isCompanion = true
                                         )
                                     ),
                                     children = listOf(Text("System.out"))

--- a/dokka-subprojects/plugin-base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/signatures/FunctionalTypeConstructorsSignatureTest.kt
@@ -113,9 +113,6 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
             configuration,
             pluginOverrides = listOf(writerPlugin)
         ) {
-            documentablesMergingStage = {
-                println(it)
-            }
             renderingStage = { _, _ ->
                 writerPlugin.writer.renderedContent("root/example/index.html").firstSignature().match(
                     "val ", A("nF"), ": (param: ", A("Int"), ") -> ", A("String"),
@@ -305,6 +302,7 @@ class FunctionalTypeConstructorsSignatureTest : BaseAbstractTest() {
         }
     }
 
+    @OnlyDescriptors("#4516")
     @OnlyJavaSymbols("#3611 - do not show open for Java fields")
     @Test
     fun `java with kotlin function`() {

--- a/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
@@ -1820,8 +1820,9 @@ class SignatureTest : BaseAbstractTest() {
             |fun Vector.length(): Double = 0.0
         """.trimMargin()
     ) {
-        val sig = renderedContent("root/example/length.html").firstSignature().toString()
-        assertTrue("companion" !in sig, "expected no 'companion' keyword for a plain extension, got: $sig")
+        renderedContent("root/example/length.html").firstSignature().matchIgnoringSpans(
+            "fun ", A("Vector"), ".", A("length"), "(): ", A("Double"),
+        )
     }
 
     @Test
@@ -1837,10 +1838,9 @@ class SignatureTest : BaseAbstractTest() {
             |}
         """.trimMargin()
     ) {
-        val sig = renderedContent("root/example/-vector/unit.html").firstSignature().toString()
-        // companion-block members live inside `companion { ... }` in source — the
-        // function itself has no `companion` modifier on it.
-        assertTrue("companion" !in sig, "expected no 'companion' keyword on companion-block function, got: $sig")
+        renderedContent("root/example/-vector/unit.html").firstSignature().matchIgnoringSpans(
+            "fun ", A("unit"), "(): ", A("Vector"),
+        )
     }
 
     @Test
@@ -1856,8 +1856,9 @@ class SignatureTest : BaseAbstractTest() {
             |}
         """.trimMargin()
     ) {
-        val sig = renderedContent("root/example/-vector/-zero.html").firstSignature().toString()
-        assertTrue("companion" !in sig, "expected no 'companion' keyword on companion-block property, got: $sig")
+        renderedContent("root/example/-vector/-zero.html").firstSignature().matchIgnoringSpans(
+            "val ", A("Zero"), ": ", A("Vector"),
+        )
     }
 
     @Test
@@ -1870,8 +1871,9 @@ class SignatureTest : BaseAbstractTest() {
             |}
         """.trimMargin()
     ) {
-        val sig = renderedContent("root/example/-util/do-stuff.html").firstSignature().toString()
-        assertTrue("companion" !in sig, "Java statics are not extensions; expected no 'companion', got: $sig")
+        renderedContent("root/example/-util/do-stuff.html").firstSignature().matchIgnoringSpans(
+            "open fun ", A("doStuff"), "(): ", A("Int"),
+        )
     }
 
     @Test
@@ -1884,8 +1886,9 @@ class SignatureTest : BaseAbstractTest() {
             |}
         """.trimMargin()
     ) {
-        val sig = renderedContent("root/example/-util/-n-a-m-e.html").firstSignature().toString()
-        assertTrue("companion" !in sig, "Java static fields are not extensions; expected no 'companion', got: $sig")
+        renderedContent("root/example/-util/-n-a-m-e.html").firstSignature().matchIgnoringSpans(
+            "val ", A("NAME"), ": ", Span("String"), " = \"x\"",
+        )
     }
 
     @Test
@@ -1896,8 +1899,9 @@ class SignatureTest : BaseAbstractTest() {
             |enum class E { A, B }
         """.trimMargin()
     ) {
-        val sig = renderedContent("root/example/-e/values.html").firstSignature().toString()
-        assertTrue("companion" !in sig, "Enum synthetic 'values' is not an extension; expected no 'companion', got: $sig")
+        renderedContent("root/example/-e/values.html").firstSignature().matchIgnoringSpans(
+            "fun ", A("values"), "(): ", A("Array"), "<", A("E"), ">",
+        )
     }
 
     @Test
@@ -1910,8 +1914,9 @@ class SignatureTest : BaseAbstractTest() {
             |fun Vector.length(): Double = 0.0
         """.trimMargin()
     ) {
-        val sig = renderedContent("root/example/length.html").firstSignature().toString()
-        assertTrue("companion" !in sig, "expected no 'companion' for plain extension, got: $sig")
+        renderedContent("root/example/length.html").firstSignature().matchIgnoringSpans(
+            "fun ", A("Vector"), ".", A("length"), "(): ", A("Double"),
+        )
     }
 
     private fun testRender(

--- a/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
@@ -1765,6 +1765,151 @@ class SignatureTest : BaseAbstractTest() {
         }
     }
 
+    // ----------------------------------------------------------------------
+    // Kotlin signatures: KEEP-0449 companion modifier.
+    //
+    // The `companion` keyword is rendered in the Kotlin signature ONLY for
+    // companion extensions — top-level extension functions/properties declared
+    // with the `companion` modifier (e.g. `companion fun Vector.unit()`).
+    //
+    // Companion-block members (`companion { fun foo() }`), Java statics, and
+    // enum synthetic declarations are also represented as companion-block scope
+    // in the model, but they don't carry a `companion` keyword in source and
+    // therefore must NOT render one in the Kotlin signature either.
+    // ----------------------------------------------------------------------
+
+    @Test
+    fun `kotlin companion extension function renders companion keyword`() = testRender(
+        """
+            |/src/main/kotlin/example/Util.kt
+            |package example
+            |class Vector(val x: Double, val y: Double)
+            |
+            |companion fun Vector.unit(): Vector = Vector(1.0, 1.0)
+        """.trimMargin()
+    ) {
+        renderedContent("root/example/-vector/unit.html").firstSignature().matchIgnoringSpans(
+            "companion fun ", A("Vector"), ".", A("unit"), "(): ", A("Vector"),
+        )
+    }
+
+    @Test
+    fun `kotlin companion extension property renders companion keyword`() = testRender(
+        """
+            |/src/main/kotlin/example/Util.kt
+            |package example
+            |class Vector(val x: Double, val y: Double)
+            |
+            |companion val Vector.UnitX: Vector get() = Vector(1.0, 0.0)
+        """.trimMargin()
+    ) {
+        renderedContent("root/example/-vector/-unit-x.html").firstSignature().matchIgnoringSpans(
+            "companion val ", A("Vector"), ".", A("UnitX"), ": ", A("Vector"),
+        )
+    }
+
+    @Test
+    fun `plain top-level extension does not render companion keyword`() = testRender(
+        """
+            |/src/main/kotlin/example/Util.kt
+            |package example
+            |class Vector(val x: Double, val y: Double)
+            |
+            |fun Vector.length(): Double = 0.0
+        """.trimMargin()
+    ) {
+        val sig = renderedContent("root/example/length.html").firstSignature().toString()
+        assertTrue("companion" !in sig, "expected no 'companion' keyword for a plain extension, got: $sig")
+    }
+
+    @Test
+    fun `kotlin companion-block function does not render companion keyword`() = testRender(
+        """
+            |/src/main/kotlin/example/Vector.kt
+            |package example
+            |class Vector(val x: Double, val y: Double) {
+            |    companion {
+            |        fun unit(): Vector = Vector(1.0, 1.0)
+            |    }
+            |}
+        """.trimMargin()
+    ) {
+        val sig = renderedContent("root/example/-vector/unit.html").firstSignature().toString()
+        // companion-block members live inside `companion { ... }` in source — the
+        // function itself has no `companion` modifier on it.
+        assertTrue("companion" !in sig, "expected no 'companion' keyword on companion-block function, got: $sig")
+    }
+
+    @Test
+    fun `kotlin companion-block property does not render companion keyword`() = testRender(
+        """
+            |/src/main/kotlin/example/Vector.kt
+            |package example
+            |class Vector(val x: Double, val y: Double) {
+            |    companion {
+            |        val Zero: Vector = Vector(0.0, 0.0)
+            |    }
+            |}
+        """.trimMargin()
+    ) {
+        val sig = renderedContent("root/example/-vector/-zero.html").firstSignature().toString()
+        assertTrue("companion" !in sig, "expected no 'companion' keyword on companion-block property, got: $sig")
+    }
+
+    @Test
+    fun `java static method does not render companion keyword in kotlin signature`() = testRender(
+        """
+            |/src/example/Util.java
+            |package example;
+            |public class Util {
+            |  public static int doStuff() { return 0; }
+            |}
+        """.trimMargin()
+    ) {
+        val sig = renderedContent("root/example/-util/do-stuff.html").firstSignature().toString()
+        assertTrue("companion" !in sig, "Java statics are not extensions; expected no 'companion', got: $sig")
+    }
+
+    @Test
+    fun `java static field does not render companion keyword in kotlin signature`() = testRender(
+        """
+            |/src/example/Util.java
+            |package example;
+            |public class Util {
+            |  public static final String NAME = "x";
+            |}
+        """.trimMargin()
+    ) {
+        val sig = renderedContent("root/example/-util/-n-a-m-e.html").firstSignature().toString()
+        assertTrue("companion" !in sig, "Java static fields are not extensions; expected no 'companion', got: $sig")
+    }
+
+    @Test
+    fun `kotlin enum synthetic values method does not render companion keyword`() = testRender(
+        """
+            |/src/main/kotlin/example/E.kt
+            |package example
+            |enum class E { A, B }
+        """.trimMargin()
+    ) {
+        val sig = renderedContent("root/example/-e/values.html").firstSignature().toString()
+        assertTrue("companion" !in sig, "Enum synthetic 'values' is not an extension; expected no 'companion', got: $sig")
+    }
+
+    @Test
+    fun `kotlin instance extension function does not render companion keyword`() = testRender(
+        """
+            |/src/main/kotlin/example/Util.kt
+            |package example
+            |class Vector(val x: Double, val y: Double)
+            |
+            |fun Vector.length(): Double = 0.0
+        """.trimMargin()
+    ) {
+        val sig = renderedContent("root/example/length.html").firstSignature().toString()
+        assertTrue("companion" !in sig, "expected no 'companion' for plain extension, got: $sig")
+    }
+
     private fun testRender(
         query: String,
         configuration: DokkaConfigurationImpl = this.configuration,

--- a/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
@@ -1788,7 +1788,7 @@ class SignatureTest : BaseAbstractTest() {
             |companion fun Vector.unit(): Vector = Vector(1.0, 1.0)
         """.trimMargin()
     ) {
-        renderedContent("root/example/-vector/unit.html").firstSignature().matchIgnoringSpans(
+        renderedContent("root/example/unit.html").firstSignature().matchIgnoringSpans(
             "companion fun ", A("Vector"), ".", A("unit"), "(): ", A("Vector"),
         )
     }
@@ -1803,7 +1803,7 @@ class SignatureTest : BaseAbstractTest() {
             |companion val Vector.UnitX: Vector get() = Vector(1.0, 0.0)
         """.trimMargin()
     ) {
-        renderedContent("root/example/-vector/-unit-x.html").firstSignature().matchIgnoringSpans(
+        renderedContent("root/example/-unit-x.html").firstSignature().matchIgnoringSpans(
             "companion val ", A("Vector"), ".", A("UnitX"), ": ", A("Vector"),
         )
     }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/signatures/SignatureTest.kt
@@ -1779,6 +1779,7 @@ class SignatureTest : BaseAbstractTest() {
     // ----------------------------------------------------------------------
 
     @Test
+    @OnlySymbols("companion block")
     fun `kotlin companion extension function renders companion keyword`() = testRender(
         """
             |/src/main/kotlin/example/Util.kt
@@ -1794,6 +1795,7 @@ class SignatureTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("companion block")
     fun `kotlin companion extension property renders companion keyword`() = testRender(
         """
             |/src/main/kotlin/example/Util.kt
@@ -1823,6 +1825,7 @@ class SignatureTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("companion block")
     fun `kotlin companion-block function does not render companion keyword`() = testRender(
         """
             |/src/main/kotlin/example/Vector.kt
@@ -1841,6 +1844,7 @@ class SignatureTest : BaseAbstractTest() {
     }
 
     @Test
+    @OnlySymbols("companion block")
     fun `kotlin companion-block property does not render companion keyword`() = testRender(
         """
             |/src/main/kotlin/example/Vector.kt

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
@@ -10,6 +10,7 @@ import org.jetbrains.dokka.pages.ClasslikePageNode
 import org.jetbrains.dokka.pages.ContentHeader
 import org.jetbrains.dokka.pages.ContentNode
 import org.jetbrains.dokka.pages.ContentText
+import utils.OnlySymbols
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -27,6 +28,7 @@ import kotlin.test.assertTrue
  *
  * They must be rendered between "Types" and "Properties"/"Functions".
  */
+@OnlySymbols("companion block")
 class CompanionSectionsTest : BaseAbstractTest() {
 
     private val configuration = dokkaConfiguration {

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertTrue
  *   - "Companion functions"
  *   - "Companion properties"
  *
- * These sections collect every documentable carrying [org.jetbrains.dokka.model.CompanionBlockMember]:
+ * These sections collect every documentable carrying [org.jetbrains.dokka.model.IsCompanion]:
  * Java static methods/fields, enum synthetic declarations (`values`/`valueOf`/`entries`),
  * Kotlin companion-block members, and companion extensions.
  *

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
@@ -140,8 +140,7 @@ class CompanionSectionsTest : BaseAbstractTest() {
                 assertEquals(listOf("valueOf", "values"), companionFns, "expected synthetic 'valueOf' and 'values' under Companion functions, got: $companionFns")
 
                 val regularFns = enumPage.sectionTexts("Functions").orEmpty()
-                assertTrue("values" !in regularFns, "synthetic 'values' must NOT appear in Functions, got: $regularFns")
-                assertTrue("valueOf" !in regularFns, "synthetic 'valueOf' must NOT appear in Functions, got: $regularFns")
+                assertEquals(emptyList(),regularFns, "no regular function is expected, got: $regularFns " )
             }
         }
     }

--- a/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/transformers/CompanionSectionsTest.kt
@@ -1,0 +1,441 @@
+/*
+ * Copyright 2014-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package transformers
+
+import org.jetbrains.dokka.base.testApi.testRunner.BaseAbstractTest
+import org.jetbrains.dokka.model.dfs
+import org.jetbrains.dokka.pages.ClasslikePageNode
+import org.jetbrains.dokka.pages.ContentHeader
+import org.jetbrains.dokka.pages.ContentNode
+import org.jetbrains.dokka.pages.ContentText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that classlike pages expose two new sections defined by KEEP-0449:
+ *   - "Companion functions"
+ *   - "Companion properties"
+ *
+ * These sections collect every documentable carrying [org.jetbrains.dokka.model.CompanionBlockMember]:
+ * Java static methods/fields, enum synthetic declarations (`values`/`valueOf`/`entries`),
+ * Kotlin companion-block members, and companion extensions.
+ *
+ * They must be rendered between "Types" and "Properties"/"Functions".
+ */
+class CompanionSectionsTest : BaseAbstractTest() {
+
+    private val configuration = dokkaConfiguration {
+        sourceSets {
+            sourceSet {
+                sourceRoots = listOf("src/")
+                classpath += jvmStdlibPath!!
+            }
+        }
+    }
+
+    private fun ClasslikePageNode.findSectionWithName(name: String): ContentNode? {
+        var sectionHeader: ContentHeader? = null
+        return content.dfs { node ->
+            node.children.filterIsInstance<ContentHeader>().any { header ->
+                header.children.firstOrNull { it is ContentText && it.text == name }
+                    ?.also { sectionHeader = header } != null
+            }
+        }?.children?.dropWhile { child -> child != sectionHeader }?.drop(1)?.firstOrNull()
+    }
+
+    private fun ClasslikePageNode.sectionTexts(name: String): List<String>? =
+        findSectionWithName(name)?.children?.mapNotNull {
+            (it.dfs { node -> node is ContentText } as? ContentText)?.text
+        }
+
+    private fun ClasslikePageNode.headerOrder(): List<String> {
+        val seen = mutableListOf<String>()
+        content.dfs { node ->
+            for (h in node.children.filterIsInstance<ContentHeader>()) {
+                val text = h.children.firstOrNull { it is ContentText }?.let { (it as ContentText).text }
+                if (text != null && text !in seen) seen += text
+            }
+            false
+        }
+        return seen
+    }
+
+    @Test
+    fun `java static method appears under Companion functions section`() {
+        testInline(
+            """
+            |/src/example/Util.java
+            |package example;
+            |public class Util {
+            |  public static int doStuff() { return 0; }
+            |  public int instanceFn() { return 1; }
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val util = root.dfs { it.name == "Util" } as? ClasslikePageNode
+                    ?: error("Util page not found")
+
+                val companionFns = util.sectionTexts("Companion functions")
+                assertNotNull(companionFns, "Companion functions section must exist")
+                assertEquals(listOf("doStuff"), companionFns, "expected 'doStuff' under Companion functions, got: $companionFns")
+
+                val regularFns = util.sectionTexts("Functions").orEmpty()
+                assertEquals(listOf("instanceFn"), regularFns, "instance method must remain in Functions, got: $regularFns")
+            }
+        }
+    }
+
+    @Test
+    fun `java static field appears under Companion properties section`() {
+        testInline(
+            """
+            |/src/example/Util.java
+            |package example;
+            |public class Util {
+            |  public static final String NAME = "x";
+            |  public int instanceField;
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val util = root.dfs { it.name == "Util" } as? ClasslikePageNode
+                    ?: error("Util page not found")
+
+                val companionProps = util.sectionTexts("Companion properties")
+                assertNotNull(companionProps, "Companion properties section must exist")
+                assertEquals(listOf("NAME"), companionProps, "expected 'NAME' under Companion properties, got: $companionProps")
+
+                val regularProps = util.sectionTexts("Properties").orEmpty()
+                assertEquals(listOf("instanceField"), regularProps, "instance field must remain in Properties, got: $regularProps")
+            }
+        }
+    }
+
+    @Test
+    fun `enum synthetic declarations appear under Companion functions section`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/E.kt
+            |package example
+            |enum class E { A, B }
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val enumPage = root.dfs { it.name == "E" } as? ClasslikePageNode
+                    ?: error("E page not found")
+                val companionFns = enumPage.sectionTexts("Companion functions")
+                    ?: error("Companion functions section must exist on enum page")
+
+                assertEquals(listOf("valueOf", "values"), companionFns, "expected synthetic 'valueOf' and 'values' under Companion functions, got: $companionFns")
+
+                val regularFns = enumPage.sectionTexts("Functions").orEmpty()
+                assertTrue("values" !in regularFns, "synthetic 'values' must NOT appear in Functions, got: $regularFns")
+                assertTrue("valueOf" !in regularFns, "synthetic 'valueOf' must NOT appear in Functions, got: $regularFns")
+            }
+        }
+    }
+
+    @Test
+    fun `Companion functions section appears after Types section`() {
+        testInline(
+            """
+            |/src/example/Util.java
+            |package example;
+            |public class Util {
+            |  public static class Nested {}
+            |  public static int doStuff() { return 0; }
+            |  public static final String NAME = "x";
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val util = root.dfs { it.name == "Util" } as? ClasslikePageNode
+                    ?: error("Util page not found")
+                val order = util.headerOrder()
+
+                // The expected ordering puts companion sections right after Types and before
+                // the regular Functions/Properties sections.
+                val types = order.indexOf("Types")
+                val companionProps = order.indexOf("Companion properties")
+                val companionFns = order.indexOf("Companion functions")
+
+                assertTrue(types >= 0, "Types section must exist, headers were: $order")
+                assertTrue(companionProps >= 0, "Companion properties section must exist, headers were: $order")
+                assertTrue(companionFns >= 0, "Companion functions section must exist, headers were: $order")
+
+                assertTrue(types < companionProps, "Types must come before Companion properties, headers were: $order")
+                assertTrue(types < companionFns, "Types must come before Companion functions, headers were: $order")
+            }
+        }
+    }
+
+    @Test
+    fun `class without static members has no companion sections`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Plain.kt
+            |package example
+            |class Plain {
+            |    fun foo() {}
+            |    val bar: Int = 0
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val plain = root.dfs { it.name == "Plain" } as? ClasslikePageNode
+                    ?: error("Plain page not found")
+                assertNull(plain.findSectionWithName("Companion functions"),
+                    "no Companion functions section should be present")
+                assertNull(plain.findSectionWithName("Companion properties"),
+                    "no Companion properties section should be present")
+            }
+        }
+    }
+
+    @Test
+    fun `companion object members do not move into Companion functions section`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Holder.kt
+            |package example
+            |class Holder {
+            |    companion object {
+            |        fun create(): Holder = Holder()
+            |    }
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val holder = root.dfs { it.name == "Holder" && it is ClasslikePageNode } as? ClasslikePageNode
+                    ?: error("Holder page not found")
+                // Holder's own page must not have any Companion functions section coming
+                // from its companion object — companion-object members live on the Companion
+                // page, not in the enclosing class's static scope.
+                assertNull(holder.findSectionWithName("Companion functions"),
+                    "Companion functions section must not be present on Holder for companion-object members")
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // KEEP-0449 Kotlin companion blocks: members declared inside a
+    // `companion { ... }` block on a class. The Kotlin source has no instance
+    // receiver for them, and Dokka collects them in the same companion-block
+    // scope as Java statics and enum synthetic declarations.
+    // ----------------------------------------------------------------------
+
+    @Test
+    fun `kotlin companion-block function appears under Companion functions section`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Vector.kt
+            |package example
+            |class Vector(val x: Double, val y: Double) {
+            |    fun length(): Double = 0.0
+            |    companion {
+            |        fun unit(): Vector = Vector(1.0, 1.0)
+            |        fun zero(): Vector = Vector(0.0, 0.0)
+            |    }
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val page = root.dfs { it.name == "Vector" } as? ClasslikePageNode
+                    ?: error("Vector page not found")
+
+                val companionFns = page.sectionTexts("Companion functions")
+                assertNotNull(companionFns, "Companion functions section must exist")
+                assertEquals(listOf("unit", "zero"), companionFns,
+                    "companion-block fun 'unit' must appear under Companion functions, got: $companionFns")
+
+                val regularFns = page.sectionTexts("Functions").orEmpty()
+                assertEquals(listOf("length"), regularFns,
+                    "instance fun 'length' must remain in Functions, got: $regularFns")
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin companion-block property appears under Companion properties section`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Vector.kt
+            |package example
+            |class Vector(val x: Double, val y: Double) {
+            |    val name: String = "v"
+            |    companion {
+            |        val Zero: Vector = Vector(0.0, 0.0)
+            |    }
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val page = root.dfs { it.name == "Vector" } as? ClasslikePageNode
+                    ?: error("Vector page not found")
+
+                val companionProps = page.sectionTexts("Companion properties")
+                assertNotNull(companionProps, "Companion properties section must exist")
+                assertEquals(listOf("Zero"), companionProps,
+                    "companion-block val 'Zero' must appear under Companion properties, got: $companionProps")
+
+                val regularProps = page.sectionTexts("Properties").orEmpty()
+                assertEquals(listOf("name", "x", "y"), regularProps,
+                    "instance val 'name' must remain in Properties, got: $regularProps")
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin companion-block const val appears under Companion properties section`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Vector.kt
+            |package example
+            |class Vector(val x: Double, val y: Double) {
+            |    companion {
+            |        const val Dimensions: Int = 2
+            |    }
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val page = root.dfs { it.name == "Vector" } as? ClasslikePageNode
+                    ?: error("Vector page not found")
+                val companionProps = page.sectionTexts("Companion properties")
+                    ?: error("Companion properties section must exist")
+                assertTrue("Dimensions" in companionProps,
+                    "const val 'Dimensions' must appear under Companion properties, got: $companionProps")
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin companion-block sections appear after Types section`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Vector.kt
+            |package example
+            |class Vector(val x: Double, val y: Double) {
+            |    class Nested()
+            |
+            |    companion {
+            |        fun unit(): Vector = Vector(1.0, 1.0)
+            |        val Zero: Vector = Vector(0.0, 0.0)
+            |    }
+            |}
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val page = root.dfs { it.name == "Vector" } as? ClasslikePageNode
+                    ?: error("Vector page not found")
+                val order = page.headerOrder()
+
+                val types = order.indexOf("Types")
+                val companionProps = order.indexOf("Companion properties")
+                val companionFns = order.indexOf("Companion functions")
+
+                assertTrue(types >= 0, "Types section must exist, headers: $order")
+                assertTrue(companionProps >= 0, "Companion properties section must exist, headers: $order")
+                assertTrue(companionFns >= 0, "Companion functions section must exist, headers: $order")
+                assertTrue(types < companionProps,
+                    "Types must come before Companion properties, headers: $order")
+                assertTrue(types < companionFns,
+                    "Types must come before Companion functions, headers: $order")
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin companion extension appears under receiver's Companion functions section`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Util.kt
+            |package example
+            |class Vector(val x: Double, val y: Double)
+            |
+            |companion fun Vector.unit(): Vector = Vector(1.0, 1.0)
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val page = root.dfs { it.name == "Vector" } as? ClasslikePageNode
+                    ?: error("Vector page not found")
+                val companionFns = page.sectionTexts("Companion functions")
+                    ?: error("Companion functions section must exist on Vector")
+                assertEquals(listOf("unit"), companionFns,
+                    "companion extension 'unit' must appear under Vector's Companion functions, got: $companionFns")
+
+                val regularFns = page.sectionTexts("Functions").orEmpty()
+                assertTrue("unit" !in regularFns,
+                    "companion extension 'unit' must NOT appear in regular Functions, got: $regularFns")
+            }
+        }
+    }
+
+    @Test
+    fun `kotlin companion extension property appears under receiver's Companion properties section`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Util.kt
+            |package example
+            |class Vector(val x: Double, val y: Double)
+            |
+            |companion val Vector.UnitX: Vector get() = Vector(1.0, 0.0)
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val page = root.dfs { it.name == "Vector" } as? ClasslikePageNode
+                    ?: error("Vector page not found")
+                val companionProps = page.sectionTexts("Companion properties")
+                    ?: error("Companion properties section must exist on Vector")
+                assertTrue("UnitX" in companionProps,
+                    "companion extension property 'UnitX' must appear under Vector's Companion properties, got: $companionProps")
+
+                val regularProps = page.sectionTexts("Properties").orEmpty()
+                assertTrue("UnitX" !in regularProps,
+                    "companion extension 'UnitX' must NOT appear in regular Properties, got: $regularProps")
+            }
+        }
+    }
+
+    @Test
+    fun `plain top-level extension stays in regular Functions section`() {
+        testInline(
+            """
+            |/src/main/kotlin/example/Util.kt
+            |package example
+            |class Vector(val x: Double, val y: Double)
+            |
+            |fun Vector.length(): Double = 0.0
+            """.trimIndent(),
+            configuration
+        ) {
+            pagesTransformationStage = { root ->
+                val page = root.dfs { it.name == "Vector" } as? ClasslikePageNode
+                    ?: error("Vector page not found")
+                val regularFns = page.sectionTexts("Functions").orEmpty()
+                assertTrue("length" in regularFns,
+                    "plain extension 'length' must remain in Functions, got: $regularFns")
+                assertNull(page.findSectionWithName("Companion functions"),
+                    "plain extensions must not create a Companion functions section")
+            }
+        }
+    }
+}

--- a/dokka-subprojects/plugin-base/src/test/kotlin/utils/contentUtils.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/utils/contentUtils.kt
@@ -328,12 +328,16 @@ inline fun<reified T> PageNode.contentPage(name: String, block: T.() -> Unit) {
     (dfs { it.name == name } as? T).assertNotNull("The page `$name` is not found").block()
 }
 
-fun ClasslikePageNode.assertHasFunctions(vararg expectedFunctionName: String) {
-    val functions = this.findSectionWithName("Functions").assertNotNull("Functions")
+fun ClasslikePageNode.assertHasFunctions(vararg expectedFunctionName: String) = assertHasSignatures("Functions", *expectedFunctionName)
+
+fun ClasslikePageNode.assertHasCompanionFunctions(vararg expectedFunctionName: String) = assertHasSignatures("Companion functions", *expectedFunctionName)
+
+
+private fun ClasslikePageNode.assertHasSignatures(sectionName: String, vararg expectedFunctionName: String) {
+    val functions = this.findSectionWithName(sectionName).assertNotNull(sectionName)
     val functionsName = functions.children.map { (it.dfs { it is ContentText } as ContentText).text }
     assertEquals(expectedFunctionName.toList(), functionsName)
 }
-
 fun ClasslikePageNode.findSectionWithName(name: String) : ContentNode? {
     var sectionHeader: ContentHeader? = null
     return content.dfs { node ->

--- a/dokka-subprojects/plugin-base/src/test/kotlin/utils/contentUtils.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/utils/contentUtils.kt
@@ -331,12 +331,13 @@ inline fun<reified T> PageNode.contentPage(name: String, block: T.() -> Unit) {
 fun ClasslikePageNode.assertHasFunctions(vararg expectedFunctionName: String) = assertHasSignatures("Functions", *expectedFunctionName)
 
 fun ClasslikePageNode.assertHasCompanionFunctions(vararg expectedFunctionName: String) = assertHasSignatures("Companion functions", *expectedFunctionName)
+fun ClasslikePageNode.assertHasCompanionProperty(vararg expectedPropertyName: String) = assertHasSignatures("Companion properties", *expectedPropertyName)
 
 
 private fun ClasslikePageNode.assertHasSignatures(sectionName: String, vararg expectedFunctionName: String) {
-    val functions = this.findSectionWithName(sectionName).assertNotNull(sectionName)
-    val functionsName = functions.children.map { (it.dfs { it is ContentText } as ContentText).text }
-    assertEquals(expectedFunctionName.toList(), functionsName)
+    val signatures = this.findSectionWithName(sectionName).assertNotNull(sectionName)
+    val names = signatures.children.map { (it.dfs { it is ContentText } as ContentText).text }
+    assertEquals(expectedFunctionName.toList(), names)
 }
 fun ClasslikePageNode.findSectionWithName(name: String) : ContentNode? {
     var sectionHeader: ContentHeader? = null

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ javaDiffUtils = "4.12"
 
 ## Analysis
 kotlin-compiler = "2.4.0-dev-5318"
-kotlin-compiler-k2 = "2.4.0-dev-5318"
+kotlin-compiler-k2 = "2.4.20-dev-3843"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations


### PR DESCRIPTION


**What changes**

• Model. New experimental CompanionBlockMember extra (and a `Callable.isCompanion` flag on the DRI) representing companion-block scope. Used to unify Java statics, enum synthetic `values/valueOf/entries`, Kotlin companion-block members, and companion extensions under one concept. 
• Analysis. The K2 symbol translator and the Java PSI parser tag matching declarations with `CompanionBlockMember`. 
• Rendering. Two new sections — `Companion functions` and `Companion properties` — appear on classlike pages after `Types` and before `Functions/Properties`. The `companion` keyword is emitted in Kotlin signatures only for companion extensions.

----

Most unit tests are generated by AI.