### PR TITLE
Update Analysis API to 2.4.20-dev-5364

### DIFF
--- a/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
+++ b/dokka-subprojects/analysis-kotlin-symbols/build.gradle.kts
@@ -45,6 +45,9 @@ dependencies {
         libs.kotlin.low.level.api.fir,
         libs.kotlin.analysis.api.platform,
         libs.kotlin.symbol.light.classes,
+        // provides `org.jetbrains.kotlin.analysis.decompiler.*` classes (e.g. ClsKotlinBinaryClassCache),
+        // which since 2.4.20-dev-5364 are no longer bundled in `kotlin-compiler`
+        libs.kotlin.compiler.k2.common,
     ).forEach {
         runtimeOnly(it) {
             isTransitive = false // see KTIJ-19820

--- a/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/ResolveKDocLink.kt
+++ b/dokka-subprojects/analysis-kotlin-symbols/src/main/kotlin/org/jetbrains/dokka/analysis/kotlin/symbols/kdoc/ResolveKDocLink.kt
@@ -15,10 +15,10 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaSourceModule
 import org.jetbrains.kotlin.analysis.api.projectStructure.contextModule
 import org.jetbrains.kotlin.analysis.api.symbols.*
-import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocLink
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocName
+import org.jetbrains.kotlin.psi.KtExperimentalApi
 import org.jetbrains.kotlin.psi.KtPsiFactory
 
 /**
@@ -162,7 +162,8 @@ private fun resolveKDocLinkToDRI(kDocLink: KDocLink): DRI? {
 
 private fun KaSession.resolveToSymbol(kDocLink: KDocLink): KaSymbol? {
     val lastNameSegment = kDocLink.children.filterIsInstance<KDocName>().lastOrNull()
-    return lastNameSegment?.mainReference?.resolveToSymbols()?.sortedWith(linkCandidatesComparator)?.firstOrNull()
+    @OptIn(KaExperimentalApi::class, KtExperimentalApi::class)
+    return lastNameSegment?.resolveSymbols()?.sortedWith(linkCandidatesComparator)?.firstOrNull()
 }
 
 /**

--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
@@ -1332,7 +1332,7 @@ class LinkTest : BaseAbstractTest() {
                             "Storage",
                             Callable("setValue", null, listOf(JavaClassReference("java.lang.String")))
                         ),
-                        "Storage.prop" to DRI("example", "Storage", Callable("getProp", null, emptyList()))
+                        "Storage.prop" to DRI("example", "Storage", Callable("prop", null, emptyList(), isProperty = true))
                     ),
                     module.getAllLinkDRIFrom("usage")
                 )

--- a/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
+++ b/dokka-subprojects/plugin-base/src/test/kotlin/markdown/LinkTest.kt
@@ -1332,6 +1332,7 @@ class LinkTest : BaseAbstractTest() {
                             "Storage",
                             Callable("setValue", null, listOf(JavaClassReference("java.lang.String")))
                         ),
+                        // refers to a Java synthetic property, see https://youtrack.jetbrains.com/issue/KT-86394
                         "Storage.prop" to DRI("example", "Storage", Callable("prop", null, emptyList(), isProperty = true))
                     ),
                     module.getAllLinkDRIFrom("usage")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ javaDiffUtils = "4.12"
 
 ## Analysis
 kotlin-compiler = "2.4.0-dev-5318"
-kotlin-compiler-k2 = "2.4.20-dev-3843"
+kotlin-compiler-k2 = "2.4.20-dev-5364"
 
 # MUST match the version of the intellij platform used in the kotlin compiler,
 # otherwise this will lead to different versions of psi API and implementations
@@ -110,6 +110,9 @@ kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref
 
 ###### K2 analysis ######
 kotlin-compiler-k2 = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin-compiler-k2" }
+# Since 2.4.20-dev-5364 the `org.jetbrains.kotlin.analysis.decompiler.*` classes (e.g. ClsKotlinBinaryClassCache,
+# required by StandaloneProjectFactory) were moved out of `kotlin-compiler` into this artifact.
+kotlin-compiler-k2-common = { module = "org.jetbrains.kotlin:kotlin-compiler-common-for-ide", version.ref = "kotlin-compiler-k2" }
 kotlin-analysis-api-api = { module = "org.jetbrains.kotlin:analysis-api-for-ide", version.ref = "kotlin-compiler-k2" }
 kotlin-analysis-api-impl = { module = "org.jetbrains.kotlin:analysis-api-impl-base-for-ide", version.ref = "kotlin-compiler-k2" }
 kotlin-analysis-api-fir = { module = "org.jetbrains.kotlin:analysis-api-k2-for-ide", version.ref = "kotlin-compiler-k2" }


### PR DESCRIPTION
Contains: 
- https://youtrack.jetbrains.com/issue/KT-85112/AA-does-not-see-packages-from-unpacked-klibs
- https://youtrack.jetbrains.com/issue/KT-86370/KDoc-links-to-extensions-members-of-a-companion-block-should-be-resolved